### PR TITLE
feat: Cập nhật các chức năng, giao diện và db cho phần trang tin tức của web

### DIFF
--- a/src/main/java/com/example/backend/controller/user/BlogServlet.java
+++ b/src/main/java/com/example/backend/controller/user/BlogServlet.java
@@ -1,4 +1,52 @@
 package com.example.backend.controller.user;
 
-public class BlogServlet {
+import com.example.backend.dao.BlogDAO;
+import com.example.backend.model.BlogPost;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+@WebServlet(name="BlogServlet",value = "/news")
+public class BlogServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        BlogDAO blogDAO = new BlogDAO();
+        int pageSize = 6;
+        int curPage = 1;
+        String param = request.getParameter("page");
+        if(param!=null && !param.trim().isEmpty()){
+            try {
+                curPage = Integer.parseInt(param);
+            } catch (NumberFormatException e) {
+                curPage =1;
+            }
+        }
+        int totalBlog = blogDAO.getTotalPost();
+        int totalPage = (int) Math.ceil((double) totalBlog / pageSize);
+        if(totalPage==0){
+            totalPage = 1;
+        }
+        if(curPage <1){
+            curPage = 1;
+        }else if(curPage>totalPage){
+            curPage = totalPage;
+        }
+        List<BlogPost> post = blogDAO.getPostByPage(curPage,pageSize);
+        List<BlogPost> feature = blogDAO.getFeaturedPosts(5);
+        request.setAttribute("posts",post);
+        request.setAttribute("featuredPosts",feature);
+        request.setAttribute("currentPage",curPage);
+        request.setAttribute("totalPages",totalPage);
+        request.getRequestDispatcher("/news.jsp").forward(request,response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doGet(request, response);
+    }
 }

--- a/src/main/java/com/example/backend/controller/user/NewsDetailServlet.java
+++ b/src/main/java/com/example/backend/controller/user/NewsDetailServlet.java
@@ -1,0 +1,47 @@
+package com.example.backend.controller.user;
+
+import com.example.backend.dao.BlogDAO;
+import com.example.backend.model.BlogPost;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+@WebServlet(name="NewsDetailServlet", value = "/news-detail")
+public class NewsDetailServlet  extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String param = request.getParameter("id");
+        BlogDAO blogDAO = new BlogDAO();
+        List<BlogPost> feature = blogDAO.getFeaturedPosts(5);
+        request.setAttribute("featuredPosts",feature);
+        if(param==null||param.trim().isEmpty()){
+            request.setAttribute("errorMessage","Không tìm thấy bài viết");
+            request.getRequestDispatcher("/news-detail.jsp").forward(request,response);
+            return;
+        }
+        try {
+            int id = Integer.parseInt(param);
+            BlogPost post = blogDAO.getPostById(id);
+            if(post == null){
+                request.setAttribute("errorMessage" , "Bài viết không tồn tại");
+            }else{
+                request.setAttribute("post",post);
+            }
+            request.getRequestDispatcher("/news-detail.jsp").forward(request,response);
+        }catch (NumberFormatException e){
+            request.setAttribute("errorMessage","Lỗi đường dẫn");
+            request.getRequestDispatcher("/news-detail.jsp").forward(request,response);
+        }
+
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doGet(request,response);
+    }
+}

--- a/src/main/java/com/example/backend/controller/user/NewsServlet.java
+++ b/src/main/java/com/example/backend/controller/user/NewsServlet.java
@@ -10,7 +10,7 @@ import jakarta.servlet.annotation.*;
 import java.io.IOException;
 import java.util.List;
 
-@WebServlet(name = "NewsServlet", value = "/news")
+@WebServlet(name = "NewsServlet", value = "/news-old")
 public class NewsServlet extends HttpServlet {
 
     private BlogDAO blogDAO = new BlogDAO();

--- a/src/main/java/com/example/backend/controller/user/VnPayReturnServlet.java
+++ b/src/main/java/com/example/backend/controller/user/VnPayReturnServlet.java
@@ -4,6 +4,7 @@ import com.example.backend.model.Cart;
 import com.example.backend.model.CartItem;
 import com.example.backend.model.Order;
 import com.example.backend.model.OrderItem;
+import com.example.backend.util.VnPayConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -12,12 +13,50 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
-import java.util.List;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 @WebServlet("/vnpay-return")
 public class VnPayReturnServlet extends  HttpServlet{
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        Map<String,String> field = new HashMap<>();
+        for(Enumeration<String> params = request.getParameterNames(); params.hasMoreElements();){
+            String filedName = params.nextElement();
+            String filedValue = request.getParameter(filedName);
+            if((filedValue!=null)&&(filedValue.length()>0)){
+                field.put(filedName,filedValue);
+            }
+        }
+        String vnp_SecureHash = request.getParameter("vnp_SecureHash");
+        if(field.containsKey("vnp_SecureHashType")){
+            field.remove("vnp_SecureHashType");
+        }
+        if(field.containsKey("vnp_SecureHash")){
+            field.remove("vnp_SecureHash");
+        }
+
+        List<String> fieldNames = new ArrayList<>(field.keySet());
+        Collections.sort(fieldNames);
+        StringBuilder br = new StringBuilder();
+        Iterator<String> itr = fieldNames.iterator();
+        while(itr.hasNext()){
+            String fieldName = itr.next();
+            String fieldValue =field.get(fieldName);
+            if((fieldValue!=null)&& (fieldValue.length()>0)){
+                br.append(fieldName);
+                br.append('=');
+                br.append(URLEncoder.encode(fieldValue, StandardCharsets.US_ASCII));
+                if(itr.hasNext()){
+                    br.append('&');
+                }
+            }
+        }
+
+        String signValue = VnPayConfig.hmacSHA512(VnPayConfig.vnp_HashSecret,br.toString());
+
+        if(signValue.equals(vnp_SecureHash)){
         String vnPayRespone = request.getParameter("vnp_ResponseCode");
         if("00".equals(vnPayRespone)){
             String txnRef = request.getParameter("vnp_TxnRef");
@@ -66,8 +105,12 @@ public class VnPayReturnServlet extends  HttpServlet{
             request.getRequestDispatcher("order-success.jsp").forward(request,response);
         }else{
             response.sendRedirect("shopping-cart.jsp");
+        }}else{
+            System.out.println("Chữ ký VnPay không hợp lệ");
+            response.sendRedirect("shopping-cart.jsp?error=invalid_signature");
         }
     }
+
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         doGet(request,response);

--- a/src/main/java/com/example/backend/dao/BlogDAO.java
+++ b/src/main/java/com/example/backend/dao/BlogDAO.java
@@ -87,5 +87,46 @@ public class BlogDAO {
         }
         return list;
     }
+    public int getTotalPost(){
+        String sql = "Select count(*) from blog_posts";
+        try(Connection con = DBConnection.getConnection();
+            PreparedStatement pre = con.prepareStatement(sql);
+            ResultSet rs = pre.executeQuery()){
+            if(rs.next()){
+                return rs.getInt(1);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+    public List<BlogPost> getPostByPage(int page, int pageSize){
+        List<BlogPost> list = new ArrayList<>();
+        int offset = (page-1)*pageSize;
+        String sql = "select * from blog_posts order by created_at desc limit ? offset ?";
+
+        try(Connection con = DBConnection.getConnection();
+            PreparedStatement pre = con.prepareStatement(sql)){
+            pre.setInt(1,pageSize);
+            pre.setInt(2,offset);
+            try(ResultSet re = pre.executeQuery()){
+                while(re.next()) {
+                    BlogPost p = new BlogPost();
+                    p.setId(re.getInt("id"));
+                    p.setTitle(re.getString("title"));
+                    p.setContent(re.getString("content"));
+                    p.setFeaturedImageUrl(re.getString("featured_image_url"));
+                    p.setCategoryId(re.getInt("category_id"));
+                    p.setFeatured(re.getBoolean("is_featured"));
+                    p.setCreatedAt(re.getTimestamp("created_at"));
+                    p.setUpdatedAt(re.getTimestamp("updated_at"));
+                    list.add(p);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
 
 }

--- a/src/main/java/com/example/backend/dao/BlogDAO.java
+++ b/src/main/java/com/example/backend/dao/BlogDAO.java
@@ -128,5 +128,29 @@ public class BlogDAO {
         }
         return list;
     }
+    public BlogPost getPostById(int id){
+        String sql ="select * from blog_posts where id = ?";
+        try (Connection con = DBConnection.getConnection();
+            PreparedStatement pre = con.prepareStatement(sql)){
+            pre.setInt(1,id);
+            try (ResultSet re = pre.executeQuery()) {
+                if (re.next()) {
+                    BlogPost p = new BlogPost();
+                    p.setId(re.getInt("id"));
+                    p.setTitle(re.getString("title"));
+                    p.setContent(re.getString("content"));
+                    p.setFeaturedImageUrl(re.getString("featured_image_url"));
+                    p.setCategoryId(re.getInt("category_id"));
+                    p.setFeatured(re.getBoolean("is_featured"));
+                    p.setCreatedAt(re.getTimestamp("created_at"));
+                    p.setUpdatedAt(re.getTimestamp("updated_at"));
+                    return p;
+                }
+            }
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+        return null;
+    }
 
 }

--- a/src/main/webapp/css/news-detail.css
+++ b/src/main/webapp/css/news-detail.css
@@ -132,6 +132,7 @@ img {
     width: 100%;
     object-fit: cover;
     border-radius: 5%;
+    aspect-ratio: 16 / 9;
 }
 
 .news-text {
@@ -174,4 +175,12 @@ img {
 
 .read-more:hover {
     text-decoration: underline;
+}
+
+.post-image-wrapper .post-featured-image {
+    width: 100%;
+    max-height: 475px;
+    object-fit: cover;
+    border-radius: 5%;
+    margin-bottom: 20px;
 }

--- a/src/main/webapp/css/news.css
+++ b/src/main/webapp/css/news.css
@@ -46,14 +46,14 @@ img {
 }
 
 .news-layout {
-    display: grid;
-    grid-template-columns: 2fr 1fr;
-    gap: 10px;
+    display: flex;
+    flex-direction: column ;
+    gap: 20px;
 }
 
 .post-gird {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(3,1fr) ;
     gap: 20px;
 }
 
@@ -63,12 +63,17 @@ img {
     flex-direction: column;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     border-radius: 10px;
+    transition: transform 0.3s ease;
+}
+.news-card:hover{
+    transform: translateY(-5px);
 }
 .block {
     padding: 10px;
 }
 .news-image img {
     width: 100%;
+    aspect-ratio: 16/9;
     object-fit: cover;
     border-radius: 10px;
 }
@@ -99,6 +104,9 @@ img {
 .news-text p {
     font-size: 14px;
     margin-top: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
     overflow: hidden;
 }
 
@@ -139,14 +147,12 @@ img {
     color: white;
 }
 
-.sidebar {
-    padding: 20px;
-    top: 30px;
-}
 
 .sidebar h2 {
     border-bottom: 2px solid #f0f0f0;
     cursor: pointer;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
 }
 
 .sidebar h2:hover {
@@ -174,27 +180,35 @@ img {
 }
 
 .post-list {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(3,1fr);
     gap: 20px;
 }
 
 .post-item {
     display: flex;
-    align-items: center;
-    gap: 10px;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 15px;
 }
 
 .news-hot-image img {
-    width: 200px;
-    height: 80px;
+    width: 100%;
+    aspect-ratio: 16 / 9;
     object-fit: cover;
-    border-radius: 10%;
+    border-radius: 6px;
+    flex-shrink: 0;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
 
 .news-hot-title a {
     font-size: 14px;
-    font-weight: 400;
+    font-weight: 500;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .news-hot-title a:hover {

--- a/src/main/webapp/news-detail.jsp
+++ b/src/main/webapp/news-detail.jsp
@@ -1,0 +1,96 @@
+<%@ page contentType="text/html; charset=UTF-8" language="java" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<fmt:setLocale value="vi_VN" />
+
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chi tiết tin tức</title>
+
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/news-detail.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/header.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/footer.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/hero-section.css">
+</head>
+<body>
+<c:set var="activeTab" value="news" scope="request"/>
+<%@ include file="compenents/header.jsp" %>
+<c:set var="pageTitle" value="Chi tiết tin tức" scope="request"/>
+<c:set var="breadcrumbText" value="<a href='${pageContext.request.contextPath}/news'>Tin tức</a> / Chi tiết" scope="request"/>
+<jsp:include page="compenents/hero-section.jsp"/>
+<section class="news-detail">
+    <div class="news-layout">
+        <main class="main-content">
+            <c:choose>
+                <c:when test="${not empty errorMessage}">
+                    <div class="error-message-container">
+                        <i class="fa-regular fa-face-frown-open error-icon"></i>
+                        <h2>Lỗi tin tức ${errorMessage}</h2>
+                        <a href="${pageContext.request.contextPath}/news" class="read-more">Quay lại xem tin tức</a>
+                    </div>
+                </c:when>
+                <c:otherwise>
+                    <article>
+                        <h2>${post.title}</h2>
+                        <span class="post-meta">
+                            <i class="fa-regular fa-calendar-days"></i>
+                            <fmt:formatDate value="${post.createdAt}" pattern="dd 'tháng' MM 'năm' yyyy"/>
+                        </span>
+                        <div class="post-image-wrapper">
+                            <img src="${post.featuredImageUrl}" alt="${post.title}" class="post-featured-image">
+                        </div>
+                        <div class="post-content">${post.content}</div>
+                    </article>
+                </c:otherwise>
+            </c:choose>
+        </main>
+        <div class="sidebar">
+            <div class="news-hot">
+                <h2>Tin tức nổi bậc</h2>
+                <div class="post-list">
+                    <c:forEach var="fp" items="${featuredPosts}">
+                        <div class="post-item">
+                            <a href="news-detail?id=${fp.id}" class="news-hot-image">
+                                <img src="${fp.featuredImageUrl}" alt="${fp.title}">
+                            </a>
+                            <div class="news-hot-title">
+                                <a href="news-detail?id=${fp.id}">${fp.title}</a>
+                            </div>
+                        </div>
+                    </c:forEach>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<c:if test="${empty errorMessage}">
+    <section class="news-down">
+        <div class="news-relate">
+            <h2>Tin tức liên quan</h2>
+        </div>
+        <div class="news-relate-grid">
+            <c:forEach var="relate" items="${featuredPosts}" begin="0" end="2">
+                <div class="news-card">
+                    <div class="news-image">
+                        <a href="news-detail?id=${relate.id}">
+                            <img src="${relate.featuredImageUrl}" alt="${relate.title}">
+                        </a>
+                    </div>
+                    <div class="news-text">
+                        <span><fmt:formatDate value="${relate.createdAt}" pattern="dd/MM/yyyy"/></span>
+                        <h3><a href="news-detail?id=${relate.id}">${relate.title}</a></h3>
+                        <p>${relate.content}</p>
+                        <a href="news-detail?id=${relate.id}" class="read-more">Xem thêm</a>
+                    </div>
+                </div>
+            </c:forEach>
+        </div>
+    </section>
+</c:if>
+<%@ include file="compenents/footer.jsp" %>
+<script src="${pageContext.request.contextPath}/js/hero-section.js"></script>
+</body>
+</html>

--- a/src/main/webapp/news-detail.jsp
+++ b/src/main/webapp/news-detail.jsp
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chi tiết tin tức</title>
 
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     <link rel="stylesheet" href="${pageContext.request.contextPath}/css/news-detail.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/css/header.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/css/footer.css">
@@ -35,13 +36,14 @@
                 <c:otherwise>
                     <article>
                         <h2>${post.title}</h2>
+
+                        <div class="post-image-wrapper">
+                            <img src="${post.featuredImageUrl}" alt="${post.title}" class="post-featured-image">
+                        </div>
                         <span class="post-meta">
                             <i class="fa-regular fa-calendar-days"></i>
                             <fmt:formatDate value="${post.createdAt}" pattern="dd 'tháng' MM 'năm' yyyy"/>
                         </span>
-                        <div class="post-image-wrapper">
-                            <img src="${post.featuredImageUrl}" alt="${post.title}" class="post-featured-image">
-                        </div>
                         <div class="post-content">${post.content}</div>
                     </article>
                 </c:otherwise>

--- a/src/main/webapp/news.jsp
+++ b/src/main/webapp/news.jsp
@@ -167,7 +167,7 @@
 
         <h3 id="searchTitle">Sản phẩm gợi ý</h3>
 
-        <div class="search-results-list">
+        <div class="search-results-list" id="searchResultArea">
         </div>
     </div>
 </div>

--- a/src/main/webapp/news.jsp
+++ b/src/main/webapp/news.jsp
@@ -91,41 +91,7 @@
             </c:if>
         </main>
         <div class="sidebar">
-            <div class="news-category">
-                <h2>Danh mục</h2>
-                <ul>
-                    <li>
-                        <a href="#">
-                            <span class="items">Phòng ăn</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            <span class="items">Trà - cà phê</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            <span class="items">Nồi sứ dưỡng sinh</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            <span class="items">Sứ dưỡng sinh</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            <span class="items">Phụ kiện bàn ăn</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#">
-                            <span class="items">Sứ nghệ thuật</span>
-                        </a>
-                    </li>
-                </ul>
-            </div>
+
             <div class="news-hot">
                     <h2>Tin tức nổi bậc</h2>
                     <div class="post-list">


### PR DESCRIPTION
  - Cập nhật logic phân trang cho trang danh sách tin tức.
  - Fix lỗi `404` cho phần tin thức bằng các thêm trang tin tiết tin tức vào thẻ xem thêm.
  - Đồng bộ kích thước các bộ ảnh để tránh ảnh to nhỏ bằng `aspect-ratio` và `object-fit: cover`.
  - Chuyển đổi grid thành 3 cột, đưa phần tin tức nổi bật xuống dưới cùng để giải quyết lỗi khoảng trắng .
  - Hiển thị mỗi trang tin tức gồm có 6 tin tức thường và 3 tin tức nổi bậc chỉnh lại các ảnh bên phần tin tức nổi bậc đều nhau kích thước 4/3.
  - Cập nhật db bảng `blog_posts`, sử dụng hình ảnh chuẩn chủ đề đồ thủ công mỹ nghệ.
 Closes #72
 Fixes #71
 Fixes #73