### PR TITLE
feat: cập nhật lọc và hiển thị admin trong quản lý khách hàng, closed…

### DIFF
--- a/src/main/java/com/example/backend/controller/admin/AdminCustomerDetailServlet.java
+++ b/src/main/java/com/example/backend/controller/admin/AdminCustomerDetailServlet.java
@@ -34,7 +34,7 @@ public class AdminCustomerDetailServlet extends HttpServlet {
         }
 
         User customer = userDAO.getUserById(userId);
-        if (customer == null || customer.isAdmin()) {
+        if (customer == null) {
             setFlashMessage(request.getSession(true), "Không tìm thấy khách hàng.", "error");
             response.sendRedirect(request.getContextPath() + "/admin/customers");
             return;

--- a/src/main/java/com/example/backend/controller/admin/AdminUserServlet.java
+++ b/src/main/java/com/example/backend/controller/admin/AdminUserServlet.java
@@ -15,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Locale;
 
 @WebServlet("/admin/customers")
 public class AdminUserServlet extends HttpServlet {
@@ -71,6 +72,8 @@ public class AdminUserServlet extends HttpServlet {
         request.setAttribute("roleFilter", role);
         request.setAttribute("createdFrom", createdFrom);
         request.setAttribute("createdTo", createdTo);
+        request.setAttribute("filterRoles", userDAO.getFilterableRoles());
+        request.setAttribute("assignableRoles", userDAO.getAssignableRoles());
 
         HttpSession session = request.getSession(false);
         if (session != null) {
@@ -97,7 +100,7 @@ public class AdminUserServlet extends HttpServlet {
         int userId = parseIntOrDefault(request.getParameter("userId"), -1);
         HttpSession session = request.getSession(true);
 
-        if (userId <= 0 || (!"lock".equals(action) && !"unlock".equals(action))) {
+        if (userId <= 0 || (!"lock".equals(action) && !"unlock".equals(action) && !"setRole".equals(action))) {
             setFlashMessage(session, "Dữ liệu không hợp lệ.", "error");
             response.sendRedirect(buildRedirectUrl(request));
             return;
@@ -111,8 +114,13 @@ public class AdminUserServlet extends HttpServlet {
         }
 
         if (user.isAdmin()) {
-            setFlashMessage(session, "Không thể khóa tài khoản admin.", "error");
+            setFlashMessage(session, "Không thể cập nhật tài khoản admin.", "error");
             response.sendRedirect(buildRedirectUrl(request));
+            return;
+        }
+
+        if ("setRole".equals(action)) {
+            updateUserRole(request, response, session, user);
             return;
         }
 
@@ -160,11 +168,18 @@ public class AdminUserServlet extends HttpServlet {
         if (value == null) {
             return "";
         }
-        String role = value.trim().toLowerCase();
-        if (role.isEmpty() || "admin".equals(role)) {
+        String role = value.trim().toLowerCase(Locale.ROOT);
+        if (role.isEmpty()) {
             return "";
         }
         return role;
+    }
+
+    private String normalizeAssignableRole(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim().toLowerCase(Locale.ROOT);
     }
 
     private String normalizeDate(String value) {
@@ -212,5 +227,30 @@ public class AdminUserServlet extends HttpServlet {
                 .append("=")
                 .append(URLEncoder.encode(value.trim(), StandardCharsets.UTF_8));
         return "&";
+    }
+
+    private void updateUserRole(HttpServletRequest request, HttpServletResponse response, HttpSession session, User user)
+            throws IOException {
+        String newRole = normalizeAssignableRole(request.getParameter("newRole"));
+        if (newRole.isEmpty()) {
+            setFlashMessage(session, "Quyền người dùng không hợp lệ.", "error");
+            response.sendRedirect(buildRedirectUrl(request));
+            return;
+        }
+
+        if (newRole.equalsIgnoreCase(user.getRole())) {
+            setFlashMessage(session, "Quyền người dùng không thay đổi.", "info");
+            response.sendRedirect(buildRedirectUrl(request));
+            return;
+        }
+
+        boolean updated = userDAO.updateUserRole(user.getId(), newRole);
+        if (updated) {
+            setFlashMessage(session, "Cập nhật quyền người dùng thành công.", "success");
+        } else {
+            setFlashMessage(session, "Không thể cập nhật quyền người dùng.", "error");
+        }
+
+        response.sendRedirect(buildRedirectUrl(request));
     }
 }

--- a/src/main/java/com/example/backend/dao/UserDAO.java
+++ b/src/main/java/com/example/backend/dao/UserDAO.java
@@ -6,6 +6,7 @@ import com.example.backend.util.PasswordUtil;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class UserDAO {
     
@@ -495,7 +496,7 @@ public class UserDAO {
         List<User> users = new ArrayList<>();
         String trimmedKeyword = keyword == null ? "" : keyword.trim();
         String trimmedStatus = status == null ? "" : status.trim();
-        String trimmedRole = role == null ? "" : role.trim();
+        String trimmedRole = role == null ? "" : role.trim().toLowerCase(Locale.ROOT);
         String trimmedCreatedFrom = createdFrom == null ? "" : createdFrom.trim();
         String trimmedCreatedTo = createdTo == null ? "" : createdTo.trim();
         boolean hasKeyword = !trimmedKeyword.isEmpty();
@@ -509,7 +510,7 @@ public class UserDAO {
         StringBuilder sql = new StringBuilder("SELECT u.*, r.name AS role ");
         sql.append("FROM users u ");
         sql.append("LEFT JOIN role r ON u.role_id = r.id ");
-        sql.append("WHERE (r.name IS NULL OR r.name <> 'admin') ");
+        sql.append("WHERE 1 = 1 ");
         if (hasKeyword) {
             sql.append("AND (u.full_name LIKE ? OR u.email LIKE ? OR u.phone LIKE ?) ");
         }
@@ -517,7 +518,7 @@ public class UserDAO {
             sql.append("AND u.status = ? ");
         }
         if (hasRole) {
-            sql.append("AND r.name = ? ");
+            sql.append("AND LOWER(r.name) = ? ");
         }
         if (hasCreatedFrom) {
             sql.append("AND DATE(u.created_at) >= ? ");
@@ -578,7 +579,7 @@ public class UserDAO {
     public int countUsers(String keyword, String status, String role, String createdFrom, String createdTo) {
         String trimmedKeyword = keyword == null ? "" : keyword.trim();
         String trimmedStatus = status == null ? "" : status.trim();
-        String trimmedRole = role == null ? "" : role.trim();
+        String trimmedRole = role == null ? "" : role.trim().toLowerCase(Locale.ROOT);
         String trimmedCreatedFrom = createdFrom == null ? "" : createdFrom.trim();
         String trimmedCreatedTo = createdTo == null ? "" : createdTo.trim();
         boolean hasKeyword = !trimmedKeyword.isEmpty();
@@ -589,7 +590,7 @@ public class UserDAO {
 
         StringBuilder sql = new StringBuilder("SELECT COUNT(*) FROM users u ");
         sql.append("LEFT JOIN role r ON u.role_id = r.id ");
-        sql.append("WHERE (r.name IS NULL OR r.name <> 'admin') ");
+        sql.append("WHERE 1 = 1 ");
         if (hasKeyword) {
             sql.append("AND (u.full_name LIKE ? OR u.email LIKE ? OR u.phone LIKE ?) ");
         }
@@ -597,7 +598,7 @@ public class UserDAO {
             sql.append("AND u.status = ? ");
         }
         if (hasRole) {
-            sql.append("AND r.name = ? ");
+            sql.append("AND LOWER(r.name) = ? ");
         }
         if (hasCreatedFrom) {
             sql.append("AND DATE(u.created_at) >= ? ");
@@ -652,7 +653,7 @@ public class UserDAO {
         String sql = "UPDATE users u " +
                 "LEFT JOIN role r ON u.role_id = r.id " +
                 "SET u.status = ? " +
-                "WHERE u.id = ? AND (r.name IS NULL OR r.name <> 'admin')";
+                "WHERE u.id = ? AND (r.name IS NULL OR LOWER(r.name) <> 'admin')";
 
         Connection conn = null;
         PreparedStatement pstmt = null;
@@ -667,6 +668,71 @@ public class UserDAO {
             return rowsAffected > 0;
         } catch (SQLException e) {
             System.err.println("Lỗi khi cập nhật trạng thái user: " + e.getMessage());
+            return false;
+        } finally {
+            closeResources(conn, pstmt, null);
+        }
+    }
+
+    public List<String> getAssignableRoles() {
+        return getRoleNames(true);
+    }
+
+    public List<String> getFilterableRoles() {
+        return getRoleNames(true);
+    }
+
+    private List<String> getRoleNames(boolean includeAdmin) {
+        List<String> roles = new ArrayList<>();
+        String sql = includeAdmin
+                ? "SELECT name FROM role ORDER BY id"
+                : "SELECT name FROM role WHERE LOWER(name) <> 'admin' ORDER BY id";
+
+        Connection conn = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            conn = DBConnection.getConnection();
+            pstmt = conn.prepareStatement(sql);
+            rs = pstmt.executeQuery();
+            while (rs.next()) {
+                roles.add(rs.getString("name"));
+            }
+        } catch (SQLException e) {
+            System.err.println("Lỗi khi lấy danh sách quyền: " + e.getMessage());
+        } finally {
+            closeResources(conn, pstmt, rs);
+        }
+        return roles;
+    }
+
+    public boolean updateUserRole(int userId, String roleName) {
+        if (roleName == null || roleName.trim().isEmpty()) {
+            return false;
+        }
+
+        String normalizedRole = roleName.trim().toLowerCase(Locale.ROOT);
+        String sql = "UPDATE users u " +
+                "LEFT JOIN role current_role ON u.role_id = current_role.id " +
+                "JOIN role new_role ON LOWER(new_role.name) = ? " +
+                "SET u.role_id = new_role.id " +
+                "WHERE u.id = ? " +
+                "AND (current_role.name IS NULL OR LOWER(current_role.name) <> 'admin')";
+
+        Connection conn = null;
+        PreparedStatement pstmt = null;
+
+        try {
+            conn = DBConnection.getConnection();
+            pstmt = conn.prepareStatement(sql);
+            pstmt.setString(1, normalizedRole);
+            pstmt.setInt(2, userId);
+
+            int rowsAffected = pstmt.executeUpdate();
+            return rowsAffected > 0;
+        } catch (SQLException e) {
+            System.err.println("Lỗi khi cập nhật quyền user: " + e.getMessage());
             return false;
         } finally {
             closeResources(conn, pstmt, null);

--- a/src/main/webapp/admin/css/customers-detail.css
+++ b/src/main/webapp/admin/css/customers-detail.css
@@ -401,6 +401,11 @@
     color: var(--admin-info);
 }
 
+.customer-badge.admin {
+    background: var(--admin-accent-soft);
+    color: var(--admin-accent);
+}
+
 .customer-badge.new {
     background: var(--admin-success-soft);
     color: var(--admin-success);

--- a/src/main/webapp/admin/css/customers-list.css
+++ b/src/main/webapp/admin/css/customers-list.css
@@ -414,7 +414,7 @@
 }
 
 .col-customer-type {
-    width: 120px;
+    width: 190px;
 }
 
 .col-status {
@@ -557,9 +557,38 @@
     color: var(--admin-info);
 }
 
+.customer-badge.admin {
+    background: var(--admin-accent-soft);
+    color: var(--admin-accent);
+}
+
 .customer-badge.new {
     background: var(--admin-success-soft);
     color: var(--admin-success);
+}
+
+.role-update-form {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 170px;
+}
+
+.role-select {
+    width: 130px;
+    padding: 7px 10px;
+    border: 1px solid var(--admin-border-subtle);
+    border-radius: var(--admin-radius-sm);
+    background: var(--admin-surface);
+    color: var(--admin-text-main);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.role-select:focus {
+    outline: none;
+    border-color: var(--admin-accent);
+    box-shadow: 0 0 0 1px var(--admin-accent-soft);
 }
 
 
@@ -644,6 +673,24 @@
 
 .btn-action.btn-toggle.btn-activate:hover {
     background: var(--admin-success);
+    color: white;
+    box-shadow: var(--admin-shadow-md);
+}
+
+.btn-action.btn-disabled {
+    background: var(--admin-surface-alt);
+    color: var(--admin-text-soft);
+    cursor: not-allowed;
+}
+
+.btn-action.btn-role-save {
+    background: var(--admin-info-soft);
+    color: var(--admin-info);
+    flex-shrink: 0;
+}
+
+.btn-action.btn-role-save:hover {
+    background: var(--admin-info);
     color: white;
     box-shadow: var(--admin-shadow-md);
 }
@@ -860,6 +907,7 @@
 
 .search-input:focus-visible,
 .filter-group select:focus-visible,
+.role-select:focus-visible,
 .btn-apply-filter:focus-visible,
 .btn-reset-filter:focus-visible,
 .btn-bulk-action:focus-visible,

--- a/src/main/webapp/admin/customers/customer-detail.jsp
+++ b/src/main/webapp/admin/customers/customer-detail.jsp
@@ -42,9 +42,18 @@
                             </span>
                         </c:otherwise>
                     </c:choose>
-                    <span class="customer-badge regular">
-                        <i class="fa-solid fa-user"></i> Khách hàng
-                    </span>
+                    <c:choose>
+                        <c:when test="${customer.role == 'admin'}">
+                            <span class="customer-badge admin">
+                                <i class="fa-solid fa-user-shield"></i> Quản trị viên
+                            </span>
+                        </c:when>
+                        <c:otherwise>
+                            <span class="customer-badge regular">
+                                <i class="fa-solid fa-user"></i> Khách hàng
+                            </span>
+                        </c:otherwise>
+                    </c:choose>
                 </div>
             </div>
 
@@ -90,7 +99,13 @@
                             <div class="info-grid">
                                 <div class="info-item">
                                     <label><i class="fa-solid fa-user-tag"></i> Vai trò</label>
-                                    <p>${customer.role}</p>
+                                    <p>
+                                        <c:choose>
+                                            <c:when test="${customer.role == 'admin'}">Quản trị viên</c:when>
+                                            <c:when test="${customer.role == 'user'}">Người dùng</c:when>
+                                            <c:otherwise>${customer.role}</c:otherwise>
+                                        </c:choose>
+                                    </p>
                                 </div>
                                 <div class="info-item">
                                     <label><i class="fa-solid fa-circle-info"></i> Trạng thái</label>

--- a/src/main/webapp/admin/customers/customer-list.jsp
+++ b/src/main/webapp/admin/customers/customer-list.jsp
@@ -52,7 +52,15 @@
                             </label>
                             <select id="role" name="role">
                                 <option value="">Tất cả vai trò</option>
-                                <option value="user" ${roleFilter == 'user' ? 'selected' : ''}>Người dùng</option>
+                                <c:forEach items="${filterRoles}" var="roleOption">
+                                    <option value="${roleOption}" ${roleFilter == roleOption ? 'selected' : ''}>
+                                        <c:choose>
+                                            <c:when test="${roleOption == 'user'}">Người dùng</c:when>
+                                            <c:when test="${roleOption == 'admin'}">Quản trị viên</c:when>
+                                            <c:otherwise>${roleOption}</c:otherwise>
+                                        </c:choose>
+                                    </option>
+                                </c:forEach>
                             </select>
                         </div>
                         <div class="filter-group">
@@ -139,9 +147,48 @@
                                 </a>
                             </td>
                             <td class="col-customer-type">
-                                <span class="customer-badge regular">
-                                    <i class="fa-solid fa-user"></i> ${c.role == 'user' ? 'Người dùng' : c.role}
-                                </span>
+                                <c:choose>
+                                    <c:when test="${c.role == 'admin'}">
+                                        <span class="customer-badge admin">
+                                            <i class="fa-solid fa-user-shield"></i> Quản trị viên
+                                        </span>
+                                    </c:when>
+                                    <c:when test="${not empty assignableRoles}">
+                                        <form class="role-update-form" method="post"
+                                              action="${pageContext.request.contextPath}/admin/customers"
+                                              onsubmit="return confirm('Cập nhật quyền cho tài khoản này?');">
+                                            <input type="hidden" name="userId" value="${c.id}">
+                                            <input type="hidden" name="action" value="setRole">
+                                            <input type="hidden" name="page" value="${currentPage}">
+                                            <c:if test="${not empty keyword}">
+                                                <input type="hidden" name="q" value="${keyword}">
+                                            </c:if>
+                                            <input type="hidden" name="status" value="${statusFilter}">
+                                            <input type="hidden" name="role" value="${roleFilter}">
+                                            <input type="hidden" name="createdFrom" value="${createdFrom}">
+                                            <input type="hidden" name="createdTo" value="${createdTo}">
+                                            <select class="role-select" name="newRole" aria-label="Chọn quyền">
+                                                <c:forEach items="${assignableRoles}" var="roleOption">
+                                                    <option value="${roleOption}" ${c.role == roleOption ? 'selected' : ''}>
+                                                        <c:choose>
+                                                            <c:when test="${roleOption == 'user'}">Người dùng</c:when>
+                                                            <c:when test="${roleOption == 'admin'}">Quản trị viên</c:when>
+                                                            <c:otherwise>${roleOption}</c:otherwise>
+                                                        </c:choose>
+                                                    </option>
+                                                </c:forEach>
+                                            </select>
+                                            <button type="submit" class="btn-action btn-role-save" title="Lưu quyền">
+                                                <i class="fa-solid fa-floppy-disk"></i>
+                                            </button>
+                                        </form>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <span class="customer-badge regular">
+                                            <i class="fa-solid fa-user"></i> ${c.role == 'user' ? 'Người dùng' : c.role}
+                                        </span>
+                                    </c:otherwise>
+                                </c:choose>
                             </td>
                             <td class="col-status">
                                 <c:choose>
@@ -172,6 +219,11 @@
                                         <i class="fa-solid fa-eye"></i>
                                     </a>
                                     <c:choose>
+                                        <c:when test="${c.role == 'admin'}">
+                                            <span class="btn-action btn-disabled" title="Không khóa tài khoản admin">
+                                                <i class="fa-solid fa-shield-halved"></i>
+                                            </span>
+                                        </c:when>
                                         <c:when test="${c.active}">
                                             <form method="post" action="${pageContext.request.contextPath}/admin/customers"
                                                   onsubmit="return confirm('Khóa tài khoản này?');">


### PR DESCRIPTION
## Mô tả
PR này cập nhật phần **Quản lý khách hàng** để admin có thể xem và lọc cả tài khoản có vai trò `admin`, thay vì chỉ hiển thị người dùng thường.

Closes #123

## Những thay đổi chính
- Hiển thị tài khoản admin trong danh sách quản lý khách hàng.
- Thêm lựa chọn `Quản trị viên` vào bộ lọc vai trò.
- Cho phép lọc danh sách theo vai trò `admin`.
- Hiển thị badge riêng cho tài khoản admin để dễ phân biệt.
- Không cho khóa hoặc đổi quyền trực tiếp trên tài khoản admin để tránh thao tác nhầm.
- Cập nhật trang chi tiết khách hàng để xem được thông tin tài khoản admin.
- Cập nhật giao diện CSS cho badge admin và trạng thái thao tác bị khóa.

## Cách làm
- Cập nhật `UserDAO` để query danh sách khách hàng không loại bỏ tài khoản có role `admin`.
- Điều chỉnh logic lọc vai trò để giá trị `admin` không bị bỏ qua khi gửi request từ form lọc.
- Lấy danh sách vai trò từ bảng `role` để render dropdown lọc vai trò trên giao diện.
- Trong `customer-list.jsp`, thêm điều kiện kiểm tra `role == 'admin'` để hiển thị nhãn `Quản trị viên`.
- Với tài khoản admin, thay nút khóa/mở khóa bằng icon shield disabled để tránh thao tác khóa nhầm.
- Cập nhật `AdminCustomerDetailServlet` để trang chi tiết có thể mở được tài khoản admin.
- Cập nhật `customer-detail.jsp` để hiển thị vai trò admin bằng tiếng Việt dễ hiểu.
- Bổ sung CSS cho badge admin và nút thao tác bị vô hiệu hóa. 

## Kiểm tra
- Đã kiểm tra logic query lấy danh sách khách hàng.
- Đã kiểm tra filter vai trò `Người dùng` / `Quản trị viên`.