### PR TITLE
feat: Gọi api tích hợp giao hàng nhanh vào checkout

### DIFF
--- a/src/main/java/com/example/backend/controller/user/CheckoutServlet.java
+++ b/src/main/java/com/example/backend/controller/user/CheckoutServlet.java
@@ -1,9 +1,11 @@
 package com.example.backend.controller.user;
 
+import com.example.backend.dao.CartDAO;
 import com.example.backend.dao.OrderDao;
 import com.example.backend.model.*;
 import com.example.backend.util.MomoConfig;
 import com.example.backend.util.VnPayConfig;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import jakarta.servlet.*;
@@ -26,6 +28,9 @@ import java.util.*;
 public class CheckoutServlet extends HttpServlet {
     private static final String POST_LOGIN_REDIRECT_KEY = "postLoginRedirect";
     private static final String CHECKOUT_FORM_SESSION_KEY = "checkoutForm";
+    private static final String GHN_TOKEN = "c3091652-699b-11f1-a973-aee5264794df";
+    private static final String GHN_SHOP_ID = "200742";
+    private static final String GHN_API_CREATE_URL = "https://dev-online-gateway.ghn.vn/shiip/public-api/v2/shipping-order/create";
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         HttpSession session = request.getSession();
@@ -38,8 +43,15 @@ public class CheckoutServlet extends HttpServlet {
             return;
         }
 
-        Cart cart = (Cart) session.getAttribute("cart");
-        if (cart == null || cart.getTotalQuantity() == 0) {
+        CartDAO cartDAO = new CartDAO();
+        List<CartItem> items = cartDAO.getCartItemsByUserId(user.getId());
+        Cart cart = new Cart();
+        if(items !=null){
+            cart.setItems(items);
+        }else{
+            cart.setItems(new ArrayList<>());
+        }
+        if (cart == null || cart.getItems().isEmpty()) {
             response.sendRedirect(request.getContextPath() + "/shopping-cart.jsp");
             return;
         }
@@ -71,7 +83,15 @@ public class CheckoutServlet extends HttpServlet {
         request.setCharacterEncoding("UTF-8");
 
         HttpSession session = request.getSession();
-        Cart cart = (Cart) session.getAttribute("cart");
+        User user = (User) session.getAttribute("user");
+        CartDAO cartDAO = new CartDAO();
+        List<CartItem> items = cartDAO.getCartItemsByUserId(user.getId());
+        Cart cart = new Cart();
+        if(items !=null){
+            cart.setItems(items);
+        }else{
+            cart.setItems(new ArrayList<>());
+        }
         List<CartItem> checkoutItems = (List<CartItem>) session.getAttribute("checkoutItems");
         Double totalCheckout = (Double) session.getAttribute("totalCheckout");
         if(cart == null || cart.getTotalQuantity() == 0) {
@@ -89,6 +109,15 @@ public class CheckoutServlet extends HttpServlet {
         String ward = request.getParameter("ward");
         String note = request.getParameter("note");
         String paymentMethod = request.getParameter("paymentMethod");
+        String shippingFeeStr = request.getParameter("shippingFee");
+        double shippingFee = 30000;
+        if(shippingFeeStr!=null&& shippingFeeStr.isEmpty()){
+            try {
+                shippingFee =Double.parseDouble(shippingFeeStr);
+            }catch (NumberFormatException e){
+                System.out.println("Lỗi tiền ship: "+e.getMessage());
+            }
+        }
 
         if(email == null || fullName == null || phone == null || address == null || paymentMethod == null){
             request.setAttribute("errorMessage","Vui lòng nhập đầy đủ thông tin và chọn phương thức thanh toán.");
@@ -99,7 +128,7 @@ public class CheckoutServlet extends HttpServlet {
         int paymentMethodId = Integer.parseInt(paymentMethod);
         cacheCheckoutForm(session, email, fullName, phone, address, province, district, ward, note);
 
-        User user = (User) session.getAttribute("user");
+
         if(user ==null){
             session.setAttribute(POST_LOGIN_REDIRECT_KEY, request.getContextPath() + "/checkout");
             response.sendRedirect(request.getContextPath() + "/login");
@@ -114,9 +143,9 @@ public class CheckoutServlet extends HttpServlet {
         order.setShipping_name(fullName);
         order.setShipping_phone(phone);
         order.setShipping_address(fullAddress);
-        order.setShipping_fee(30000);
+        order.setShipping_fee(shippingFee);
         order.setNote(note);
-        order.setTotal_amount(totalCheckout + 30000);
+        order.setTotal_amount(totalCheckout + shippingFee);
 
         order.setPayment_method_id(paymentMethodId);
 
@@ -132,7 +161,8 @@ public class CheckoutServlet extends HttpServlet {
 
             if (orderId > 0) {
                 if (paymentMethodId == 3) {
-                    long amount = (long)((totalCheckout + 30000)*100);
+                    createGHNOrder(fullName,phone,fullAddress,district,ward,0,checkoutItems);
+                    long amount = (long)((totalCheckout + shippingFee)*100);
                     String vnp_TxnRef = String.valueOf(orderId);
                     Map<String,String> vnp_Params = new HashMap<>();
                     vnp_Params.put("vnp_Version", "2.1.0");
@@ -186,7 +216,8 @@ public class CheckoutServlet extends HttpServlet {
 //                    request.setAttribute("Error", "VnPay");
 //                    request.getRequestDispatcher("/checkout.jsp").forward(request, response);
                 }else if(paymentMethodId == 2){
-                    long amount = (long) (totalCheckout + 30000);
+                    createGHNOrder(fullName, phone, fullAddress, district, ward, 0, checkoutItems);
+                    long amount = (long) (totalCheckout + shippingFee);
                     String amountStr = String.valueOf(amount);
                     String orderIdStr = orderId +"_"+System.currentTimeMillis();
                     String requestId = String.valueOf(System.currentTimeMillis());
@@ -266,6 +297,8 @@ public class CheckoutServlet extends HttpServlet {
                     }
                 }
                 else if (paymentMethodId == 1) {
+                    double totalCod = totalCheckout +shippingFee;
+                    createGHNOrder(fullName, phone, fullAddress, district, ward, totalCod, checkoutItems);
 
                     List<OrderItem> orderItems = orderDao.getOrderItems(orderId);
 //                    cart.getItems().removeAll(checkoutItems);
@@ -305,6 +338,69 @@ public class CheckoutServlet extends HttpServlet {
                 request.getRequestDispatcher("/checkout.jsp").forward(request,response);
 
             }
+    }
+    private void createGHNOrder(String toName, String toPhone, String toAddress, String districtIdStr, String wardCode, double codAmount,List<CartItem> items){
+        try{
+            int districtId = 0;
+            if(districtIdStr!=null&&!districtIdStr.isEmpty()){
+                districtId = Integer.parseInt(districtIdStr);
+            }
+            JsonObject jsonRequest = new JsonObject();
+            jsonRequest.addProperty("payment_type_id",1);
+            jsonRequest.addProperty("service_type_id", 2);
+            jsonRequest.addProperty("note", "Giao hàng vào giờ hành chính");
+            jsonRequest.addProperty("required_note", "CHOXEMHANGKHONGTHU");
+            jsonRequest.addProperty("to_name", toName);
+            jsonRequest.addProperty("to_phone", toPhone);
+            jsonRequest.addProperty("to_address", toAddress);
+            jsonRequest.addProperty("to_ward_code", wardCode);
+            jsonRequest.addProperty("to_district_id", districtId);
+            jsonRequest.addProperty("cod_amount", (int) codAmount);
+            jsonRequest.addProperty("weight", 500);
+            jsonRequest.addProperty("length", 15);
+            jsonRequest.addProperty("width", 15);
+            jsonRequest.addProperty("height", 15);
+
+            JsonArray itemsArr = new JsonArray();
+            for (CartItem item: items){
+                JsonObject itemJson = new JsonObject();
+                itemJson.addProperty("name",item.getProduct().getName());
+                itemJson.addProperty("quantity",item.getQuantity());
+                itemJson.addProperty("price",(int)item.getProduct().getPrice());
+                itemJson.addProperty("weight",200);
+                itemsArr.add(itemJson);
+            }
+            jsonRequest.add("items", itemsArr);
+            URL url = new URL(GHN_API_CREATE_URL);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setDoOutput(true);
+            con.setRequestMethod("POST");
+            con.setRequestProperty("Content-Type","application/json");
+            con.setRequestProperty("Token",GHN_TOKEN);
+            con.setRequestProperty("ShopId",GHN_SHOP_ID);
+
+            OutputStream os = con.getOutputStream();
+            BufferedReader br;
+            StringBuilder builder = new StringBuilder();
+            String input;
+            os.write(jsonRequest.toString().getBytes(StandardCharsets.UTF_8));
+            os.flush();
+            int responseCode= con.getResponseCode();
+            if(responseCode>=400){
+                br = new BufferedReader(new InputStreamReader(con.getErrorStream(),StandardCharsets.UTF_8));
+            }else{
+                br = new BufferedReader(new InputStreamReader(con.getInputStream(),StandardCharsets.UTF_8));
+            }
+            while((input = br.readLine())!=null){
+                builder.append(input);
+            }
+            br.close();
+            System.out.println("GHN order res: "+builder.toString());
+
+        }catch (Exception e){
+            System.out.println("Lỗi tạo đơn GHN: "+e.getMessage());
+            e.printStackTrace();
+        }
     }
 
     private void cacheCheckoutForm(HttpSession session, String email, String fullName, String phone,

--- a/src/main/webapp/checkout.jsp
+++ b/src/main/webapp/checkout.jsp
@@ -84,7 +84,7 @@
                         <div class="form-group">
                             <label for="province">Tỉnh / Thành phố</label>
                             <select id="province" name="province" >
-                                <option value="" disabled  selected }>Chọn Tỉnh / Thành phố</option>
+                                <option value="" disabled  selected >Chọn Tỉnh / Thành phố</option>
 
                             </select>
                         </div>
@@ -92,7 +92,7 @@
                         <div class="form-group">
                             <label for="district">Quận / Huyện</label>
                             <select id="district" name="district">
-                                <option value="" disabled   selected }>Chọn Quận / Huyện</option>
+                                <option value="" disabled   selected >Chọn Quận / Huyện</option>
 
                             </select>
                         </div>
@@ -100,7 +100,7 @@
                         <div class="form-group">
                             <label for="ward">Phường / Xã</label>
                             <select id="ward" name="ward" >
-                                <option value="" disabled  selected }>Chọn Phường / Xã</option>
+                                <option value="" disabled  selected >Chọn Phường / Xã</option>
 
                             </select>
                         </div>
@@ -121,7 +121,7 @@
                             <span>Giao hàng tận nơi</span>
                         </label>
                         <div class="shipping-price">
-                            <span>30.000 đ</span>
+                            <span id="shippingFeeDisplay1">30.000 đ</span>
                         </div>
                     </div>
                 </div>
@@ -205,14 +205,14 @@
                     </div>
                     <div class="order-total-bottom">
                         <span>Phí vận chuyển</span>
-                        <span class="price">30.000 đ</span>
+                        <span class="price" id="shippingFeeDisplay2">30.000 đ</span>
                     </div>
                 </div>
 
                 <div class="order-price">
                     <div class="order-price-top">
                         <span>Tổng cộng</span>
-                        <span class="price">
+                        <span class="price" id="finalTotalDisplay">
                             <fmt:formatNumber value="${totalCheckout + 30000}" pattern="#,### đ"/>
                         </span>
                     </div>
@@ -245,6 +245,45 @@
         const saveAddDiv = document.getElementById("savedAddressDiv");
         const newAddField = document.getElementById("newAddressFields");
         const saveAddSel = document.getElementById("savedAddressSelect");
+        const feeDisplay1 = document.getElementById("shippingFeeDisplay1");
+        const feeDisplay2 = document.getElementById("shippingFeeDisplay2");
+        const finalTotal = document.getElementById("finalTotalDisplay");
+        const totalItems = ${totalCheckout !=null?totalCheckout:0};
+        const GHN_TOKEN = "c3091652-699b-11f1-a973-aee5264794df";
+        const GHN_SHOP_ID = "200742";
+        function updateShippingFee(fee){
+            const formattedFee = new Intl.NumberFormat('vi-VN').format(fee)+' đ';
+            const total = parseInt(totalItems) +fee;
+            const formattedTotal = new Intl.NumberFormat('vi-VN').format(total) +' đ';
+            if(feeDisplay1) feeDisplay1.innerText = formattedFee;
+            if(feeDisplay2) feeDisplay2.innerText = formattedFee;
+            if(finalTotal) finalTotal.innerText = formattedTotal;
+            let feeInput = document.getElementById('shippingFeeInput');
+            if(feeInput) feeInput.value = fee;
+        }
+        function calculateShippingFee(districtId, wardCode){
+            const payload = {
+                "service_type_id": 2,
+                "to_district_id": parseInt(districtId),
+                "to_ward_code": wardCode,
+                "weight": 500,
+                "insurance_value": parseInt(totalItems)
+            };
+            fetch('https://dev-online-gateway.ghn.vn/shiip/public-api/v2/shipping-order/fee', {
+                method: 'POST',
+                headers: {
+                    'Token': GHN_TOKEN,
+                    'ShopId': GHN_SHOP_ID,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(payload)
+            }).then(response => response.json()).then(data => {
+                    if(data.code === 200 && data.data) {
+                        updateShippingFee(data.data.total);
+                    }
+                })
+                .catch(err => console.error("Lỗi tính phí ship GHN:", err));
+        }
 
         function addressMode(){
             if(optionSaved.checked){
@@ -255,6 +294,7 @@
                 districtSelect.removeAttribute("required");
                 wardSelect.removeAttribute("required");
                 fullAddress.value = saveAddSel.value;
+                updateShippingFee(30000);
             }else{
                 saveAddDiv.style.display = "none";
                 newAddField.style.display = "block";
@@ -273,16 +313,20 @@
             }
         });
         addressMode();
-        fetch('https://provinces.open-api.vn/api/p/') //danh sách tỉnh tp từ việc gọi api
+        fetch('https://dev-online-gateway.ghn.vn/shiip/public-api/master-data/province',{
+            method:'GET',headers:{'Token':GHN_TOKEN}
+        }) //danh sách tỉnh tp từ việc gọi api
             .then(response=>response.json()).then(data=>{
-                data.forEach(province=>{
+                if(data.code === 200){
+                data.data.forEach(province=>{
                     let option = document.createElement("option");
-                    option.value = province.code;
-                    option.text = province.name;
-                    option.setAttribute("data-name",province.name);
+                    option.value = province.ProvinceID;
+                    option.text = province.ProvinceName;
+                    option.setAttribute("data-name",province.ProvinceName);
                     provinceSelect.add(option);
                 });
-        });
+                }
+        }).catch(err=>console.error("Lỗi lấy Tỉnh:",err));
         provinceSelect.addEventListener("change",function (){
             // khi bấm chọn tỉnh thì load huyện
             const provinceCode = this.value;
@@ -290,17 +334,21 @@
             wardSelect.innerHTML = '<option value="" disabled selected> Chọn Phường / Xã</option>';
             wardSelect.disabled = true;
             if(provinceCode){
-                fetch('https://provinces.open-api.vn/api/p/'+provinceCode+'?depth=2')
+                fetch('https://dev-online-gateway.ghn.vn/shiip/public-api/master-data/district?province_id='+provinceCode,{
+                    method:'GET', headers:{'Token':GHN_TOKEN}
+                })
                     .then(response=>response.json())
                     .then(data =>{
-                        data.districts.forEach(district =>{
+                        if(data.code ===200){
+                        data.data.forEach(district =>{
                             let option = document.createElement("option");
-                            option.value = district.code;
-                            option.text = district.name;
-                            option.setAttribute("data-name",district.name);
+                            option.value = district.DistrictID;
+                            option.text = district.DistrictName;
+                            option.setAttribute("data-name",district.DistrictName);
                             districtSelect.add(option);
                         });
                         districtSelect.disabled = false;
+                        }
                     }).catch(err=> console.error("Lỗi danh sách huyện:", err));
             }
             updateFullAddress();
@@ -311,22 +359,32 @@
             wardSelect.innerHTML = '<option value="" disabled selected>Chọn Phường / Xã</option>';
             wardSelect.disabled = true;
             if(districtCode){
-                fetch('https://provinces.open-api.vn/api/d/'+districtCode+'?depth=2')
+                fetch('https://dev-online-gateway.ghn.vn/shiip/public-api/master-data/ward?district_id='+districtCode,{
+                    method:'GET', headers:{'Token':GHN_TOKEN}
+                })
                     .then(response=>response.json()).then(data=>{
-                        data.wards.forEach(ward=>{
+                        if(data.code===200){
+                        data.data.forEach(ward=>{
                             let option = document.createElement("option");
-                            option.value = ward.code;
-                            option.text = ward.name;
-                            option.setAttribute("data-name",ward.name);
+                            option.value = ward.WardCode;
+                            option.text = ward.WardName;
+                            option.setAttribute("data-name",ward.WardName);
                             wardSelect.add(option)
                         });
                         wardSelect.disabled = false;
+                        }
                 }).catch(err=> console.error("Lỗi danh sách xã:",err));
+                calculateShippingFee(districtCode,"");
             }
             updateFullAddress();
 
         });
-        wardSelect.addEventListener("change",updateFullAddress);
+        wardSelect.addEventListener("change",function () {
+            const districtId = districtSelect.value;
+            const wardCode = this.value;
+            calculateShippingFee(districtId,wardCode);
+            updateFullAddress();
+        });
         address.addEventListener("input",updateFullAddress);// ở xã và input nhận vào có thay đổi gì không
 
         function updateFullAddress() {


### PR DESCRIPTION
- Tích hợp API GHN để tự động load danh sách Tỉnh/Thành, Quận/Huyện, Phường/Xã.
- Gọi API tính phí vận chuyển theo thời gian thực dựa trên địa chỉ giao hàng khách đã chọn.
- Viết thêm hàm `createGHNOrder` để đẩy trực tiếp thông tin đơn hàng lên hệ thống của đơn vị vận chuyển GHN ngay khi đặt hàng thành công.
- Đã cộng dồn phí ship vào tổng tiền đơn hàng cuối cùng.
Closes #125