### PR TITLE
feat(topic2): xử lí tồn kho, tách việc quản lí kho giữa trang product ra thành 1 bảng inventory; các thống kê về sản phẩm và tồn kho

### DIFF
--- a/src/main/java/com/example/backend/controller/admin/AdminDashboardServlet.java
+++ b/src/main/java/com/example/backend/controller/admin/AdminDashboardServlet.java
@@ -1,23 +1,26 @@
 package com.example.backend.controller.admin;
 
+import com.example.backend.dao.DashboardStatisticsDAO;
 import com.example.backend.dao.OrderDao;
 import com.example.backend.model.Order;
 import com.example.backend.service.ProductService;
-import jakarta.servlet.RequestDispatcher;
+import com.google.gson.Gson;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @WebServlet(name = "AdminDashboardServlet", value = "/admin/dashboard")
 public class AdminDashboardServlet extends HttpServlet {
 
     private final ProductService productService = new ProductService();
     private final OrderDao orderDao = new OrderDao();
+    private final DashboardStatisticsDAO statsDAO = new DashboardStatisticsDAO();
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -26,27 +29,86 @@ public class AdminDashboardServlet extends HttpServlet {
         response.setCharacterEncoding("UTF-8");
 
         int totalProducts = productService.getAllProductsForAdmin(0, 10000).size();
-
         List<Order> allOrders = orderDao.getAllOrders();
+        long pendingOrders = allOrders.stream().filter(o -> "pending".equalsIgnoreCase(o.getOrder_status())).count();
 
-        long pendingOrders = 0;
-        double monthlyRevenue = 0;
+        double monthlyRevenue = statsDAO.getActualMonthlyRevenue();
 
-        for (Order o : allOrders) {
-            if ("pending".equalsIgnoreCase(o.getOrder_status())) {
-                pendingOrders++;
-            }
-            monthlyRevenue += o.getTotal_amount();
+        int currentYear = LocalDate.now().getYear();
+        List<Double> currentYearRevenue = statsDAO.getRevenueDataByYear(currentYear);
+        List<Double> lastYearRevenue = statsDAO.getRevenueDataByYear(currentYear - 1);
+
+        double totalCurrentSum = currentYearRevenue.stream().mapToDouble(Double::doubleValue).sum();
+        double totalLastSum = lastYearRevenue.stream().mapToDouble(Double::doubleValue).sum();
+        double growthRate = 0;
+        if (totalLastSum > 0) {
+            growthRate = ((totalCurrentSum - totalLastSum) / totalLastSum) * 100;
         }
 
-        
+        Gson gson = new Gson();
+        request.setAttribute("currentYearRevenueJson", gson.toJson(currentYearRevenue));
+        request.setAttribute("lastYearRevenueJson", gson.toJson(lastYearRevenue));
+        request.setAttribute("growthRate", Math.round(growthRate * 100.0) / 100.0);
+        request.setAttribute("currentYear", currentYear);
+
         request.setAttribute("totalProducts", totalProducts);
-        request.setAttribute("ordersToday", allOrders.size()); 
+        request.setAttribute("ordersToday", allOrders.size());
         request.setAttribute("pendingOrders", pendingOrders);
         request.setAttribute("monthlyRevenue", monthlyRevenue);
-        
+
         List<Order> recentOrders = allOrders.stream().limit(5).toList();
         request.setAttribute("recentOrders", recentOrders);
+
+        String compareMonthA = request.getParameter("monthA");
+        String compareYearA = request.getParameter("yearA");
+        String compareMonthB = request.getParameter("monthB");
+        String compareYearB = request.getParameter("yearB");
+
+        int mA = (compareMonthA != null) ? Integer.parseInt(compareMonthA) : 1;
+        int yA = (compareYearA != null) ? Integer.parseInt(compareYearA) : 2025;
+        int mB = (compareMonthB != null) ? Integer.parseInt(compareMonthB) : LocalDate.now().getMonthValue();
+        int yB = (compareYearB != null) ? Integer.parseInt(compareYearB) : 2026;
+
+        double revenueMocA = statsDAO.getRevenueByMonthAndYear(mA, yA);
+        double revenueMocB = statsDAO.getRevenueByMonthAndYear(mB, yB);
+        double comparisonGrowth = 0;
+        if (revenueMocA > 0) {
+            comparisonGrowth = ((revenueMocB - revenueMocA) / revenueMocA) * 100;
+        }
+
+        request.setAttribute("revenueMocA", revenueMocA);
+        request.setAttribute("revenueMocB", revenueMocB);
+        request.setAttribute("comparisonGrowth", Math.round(comparisonGrowth * 100.0) / 100.0);
+        request.setAttribute("mA", mA); request.setAttribute("yA", yA);
+        request.setAttribute("mB", mB); request.setAttribute("yB", yB);
+
+        String startDate = request.getParameter("startDate");
+        String endDate = request.getParameter("endDate");
+        if (startDate == null || startDate.trim().isEmpty()) {
+            startDate = LocalDate.now().minusMonths(1).toString();
+        }
+        if (endDate == null || endDate.trim().isEmpty()) {
+            endDate = LocalDate.now().toString();
+        }
+
+        Map<String, Integer> invFlow = statsDAO.getInventoryFlow(startDate, endDate);
+        request.setAttribute("invFlow", invFlow);
+        request.setAttribute("startDate", startDate);
+        request.setAttribute("endDate", endDate);
+
+        int totalAllImport = statsDAO.getTotalImportedQuantity();
+        int totalAllExport = statsDAO.getTotalExportedQuantity();
+
+        double salesToImportRatio = 0.0;
+        if (totalAllImport > 0) {
+            salesToImportRatio = ((double) totalAllExport / totalAllImport) * 100;
+        }
+
+        salesToImportRatio = Math.round(salesToImportRatio * 10.0) / 10.0;
+
+        request.setAttribute("totalAllImport", totalAllImport);
+        request.setAttribute("totalAllExport", totalAllExport);
+        request.setAttribute("salesToImportRatio", salesToImportRatio);
 
         request.getRequestDispatcher("/admin/dashboard.jsp").forward(request, response);
     }

--- a/src/main/java/com/example/backend/controller/admin/AdminInventoryServlet.java
+++ b/src/main/java/com/example/backend/controller/admin/AdminInventoryServlet.java
@@ -1,0 +1,59 @@
+package com.example.backend.controller.admin;
+
+import com.example.backend.dao.InventoryDao;
+import com.example.backend.model.Product;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@WebServlet(name = "AdminInventoryServlet", value = "/admin/inventory")
+public class AdminInventoryServlet extends HttpServlet {
+    private final InventoryDao inventoryDao = new InventoryDao();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<Product> inventoryList = inventoryDao.getInventoryList();
+        request.setAttribute("inventoryList", inventoryList);
+        request.getRequestDispatcher("/admin/inventory/inventory-list.jsp").forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        request.setCharacterEncoding("UTF-8");
+
+        String[] productIdsStr = request.getParameterValues("productIds");
+        String[] stockAddsStr = request.getParameterValues("stockAdds");
+
+        if (productIdsStr != null && stockAddsStr != null) {
+            List<Integer> productIds = new ArrayList<>();
+            List<Integer> quantitiesAdded = new ArrayList<>();
+
+            for (int i = 0; i < productIdsStr.length; i++) {
+                try {
+                    int pId = Integer.parseInt(productIdsStr[i]);
+                    int qAdd = stockAddsStr[i].trim().isEmpty() ? 0 : Integer.parseInt(stockAddsStr[i].trim());
+
+                    if (qAdd > 0) {
+                        productIds.add(pId);
+                        quantitiesAdded.add(qAdd);
+                    }
+                } catch (NumberFormatException e) {
+                }
+            }
+
+            if (!productIds.isEmpty()) {
+                boolean success = inventoryDao.importStockBatch(productIds, quantitiesAdded);
+                if (success) {
+                    response.sendRedirect(request.getContextPath() + "/admin/inventory?status=success");
+                    return;
+                }
+            }
+        }
+        response.sendRedirect(request.getContextPath() + "/admin/inventory?status=error");
+    }
+}

--- a/src/main/java/com/example/backend/controller/admin/AdminOrderServlet.java
+++ b/src/main/java/com/example/backend/controller/admin/AdminOrderServlet.java
@@ -35,32 +35,22 @@ public class AdminOrderServlet extends HttpServlet {
         }
     }
 
-    
+
     private void viewOrderList(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         int page = 1;
-        int pageSize = 8;
-        try {
-            if (request.getParameter("page") != null) {
-                page = Integer.parseInt(request.getParameter("page"));
-            }
-            if (request.getParameter("pageSize") != null) {
-                pageSize = Integer.parseInt(request.getParameter("pageSize"));
-            }
-        } catch (NumberFormatException e) {
-            page = 1;
-        }
-        List<Order> orders = orderDao.getAllOrders(); 
+        int pageSize = 1000;
 
-        int totalOrders = orders.size(); 
-        int totalPages = (int) Math.ceil((double) totalOrders / pageSize);
+        List<Order> orders = orderDao.getAllOrders();
+        int totalOrders = orders.size();
 
         request.setAttribute("orders", orders);
         request.setAttribute("currentPage", page);
-        request.setAttribute("totalPages", totalPages);
+        request.setAttribute("totalPages", 1);
         request.setAttribute("pageSize", pageSize);
         request.setAttribute("totalOrders", totalOrders);
 
-        request.getRequestDispatcher("/admin/orders/order-list.jsp").forward(request, response);    }
+        request.getRequestDispatcher("/admin/orders/order-list.jsp").forward(request, response);
+    }
 
     
     private void viewOrderDetail(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -100,11 +90,65 @@ public class AdminOrderServlet extends HttpServlet {
             int orderId = Integer.parseInt(request.getParameter("order_id"));
             String newStatus = request.getParameter("order_status");
 
-            
-            boolean success = orderDao.updateOrderStatus(orderId, newStatus);
+            String updateOrderSql = "UPDATE orders SET order_status = ? WHERE id = ?";
+
+            String updateStockSql = "UPDATE products p " +
+                    "JOIN order_items oi ON p.id = oi.product_id " +
+                    "SET p.stock = p.stock - oi.quantity, " +
+                    "    p.sold_quantity = p.sold_quantity + oi.quantity " +
+                    "WHERE oi.order_id = ?";
+
+            String insertTransactionSql = "INSERT INTO inventory_transactions (product_id, transaction_type, quantity, reason) " +
+                    "SELECT product_id, 'EXPORT', quantity, 'Xuất kho tự động từ đơn hàng thành công' " +
+                    "FROM order_items WHERE order_id = ?";
+
+            java.sql.Connection conn = null;
+            java.sql.PreparedStatement psOrder = null;
+            java.sql.PreparedStatement psUpdateStock = null;
+            java.sql.PreparedStatement psInsertTx = null;
+            boolean success = false;
+
+            try {
+                conn = com.example.backend.util.DBConnection.getConnection();
+                conn.setAutoCommit(false);
+
+                psOrder = conn.prepareStatement(updateOrderSql);
+                psOrder.setString(1, newStatus);
+                psOrder.setInt(2, orderId);
+                psOrder.executeUpdate();
+
+                if ("Hoàn thành".equalsIgnoreCase(newStatus) || "completed".equalsIgnoreCase(newStatus)) {
+
+                    psUpdateStock = conn.prepareStatement(updateStockSql);
+                    psUpdateStock.setInt(1, orderId);
+                    psUpdateStock.executeUpdate();
+
+                    psInsertTx = conn.prepareStatement(insertTransactionSql);
+                    psInsertTx.setInt(1, orderId);
+                    psInsertTx.executeUpdate();
+                }
+
+                conn.commit();
+                success = true;
+            } catch (Exception e) {
+                if (conn != null) {
+                    try {
+                        conn.rollback();
+                    } catch (java.sql.SQLException ex) {
+                        ex.printStackTrace();
+                    }
+                }
+                e.printStackTrace();
+            } finally {
+                try {
+                    if (psOrder != null) psOrder.close();
+                    if (psUpdateStock != null) psUpdateStock.close();
+                    if (psInsertTx != null) psInsertTx.close();
+                    if (conn != null) conn.close();
+                } catch (Exception e) { e.printStackTrace(); }
+            }
 
             if (success) {
-                
                 response.sendRedirect(request.getContextPath() + "/admin/orders?action=detail&id=" + orderId + "&status=updated");
             } else {
                 response.sendRedirect(request.getContextPath() + "/admin/orders?action=detail&id=" + orderId + "&status=error");

--- a/src/main/java/com/example/backend/controller/admin/AdminProductServlet.java
+++ b/src/main/java/com/example/backend/controller/admin/AdminProductServlet.java
@@ -1,5 +1,6 @@
 package com.example.backend.controller.admin;
 
+import com.example.backend.dao.DashboardStatisticsDAO;
 import com.example.backend.model.Product;
 import com.example.backend.model.ProductAttribute;
 import com.example.backend.model.ProductImage;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.Part;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 @WebServlet(name = "AdminProductServlet", value = "/admin/products")
@@ -25,6 +27,7 @@ import java.util.List;
 public class AdminProductServlet extends HttpServlet {
 
     private ProductService productService = new ProductService();
+    private DashboardStatisticsDAO statsDAO = new DashboardStatisticsDAO();
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -94,8 +97,10 @@ public class AdminProductServlet extends HttpServlet {
         int limit = (lengthParam != null) ? Integer.parseInt(lengthParam) : 1000;
 
         List<Product> listProducts = productService.getAllProductsForAdmin(offset, limit);
-
         request.setAttribute("listProducts", listProducts);
+
+        List<Product> outOfStockList = listProducts.stream().filter(p -> p.getStock() == 0).toList();
+        request.setAttribute("outOfStockProducts", outOfStockList);
         request.getRequestDispatcher("/admin/products/product-list.jsp").forward(request, response);
     }
 
@@ -131,7 +136,7 @@ public class AdminProductServlet extends HttpServlet {
         pImg.setImageUrl(imageUrl);
         newProduct.setImage(pImg);
 
-        productService.insertFullProduct(newProduct, pa);
+        productService.insertFullProduct(newProduct, pa, pImg);
 
         response.sendRedirect(request.getContextPath() + "/admin/products?message=inserted");
     }

--- a/src/main/java/com/example/backend/controller/user/ProductDetailServlet.java
+++ b/src/main/java/com/example/backend/controller/user/ProductDetailServlet.java
@@ -2,18 +2,30 @@ package com.example.backend.controller.user;
 
 import com.example.backend.dao.ProductDAO;
 import com.example.backend.model.Product;
+import com.example.backend.model.ProductAttribute;
+import com.example.backend.model.ProductImage;
 import com.example.backend.model.Review;
 import com.example.backend.service.ProductService;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.MultipartConfig;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.Part;
+
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 
 @WebServlet(name = "ProductDetailServlet", value = "/productdetail")
+@MultipartConfig(
+        fileSizeThreshold = 1024 * 1024 * 2,
+        maxFileSize = 1024 * 1024 * 10,
+        maxRequestSize = 1024 * 1024 * 50
+)
 public class ProductDetailServlet extends HttpServlet {
 
     private ProductService productService = new ProductService();
@@ -55,4 +67,77 @@ public class ProductDetailServlet extends HttpServlet {
 
         request.getRequestDispatcher("/productdetail.jsp").forward(request, response);
     }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        request.setCharacterEncoding("UTF-8");
+        response.setCharacterEncoding("UTF-8");
+
+        String action = request.getParameter("action");
+        String name = request.getParameter("name");
+        double price = Double.parseDouble(request.getParameter("price"));
+        int stock = Integer.parseInt(request.getParameter("stock"));
+        int categoryId = Integer.parseInt(request.getParameter("category_id"));
+        String fullDescription = request.getParameter("full_description");
+        String status = request.getParameter("status");
+        boolean isFeatured = "1".equals(request.getParameter("featured"));
+
+        String finalImageUrl = request.getParameter("image_url");
+
+        try {
+            Part filePart = request.getPart("image_file");
+            if (filePart != null && filePart.getSize() > 0) {
+                String fileName = Paths.get(filePart.getSubmittedFileName()).getFileName().toString();
+                if (!fileName.isEmpty()) {
+                    String uniqueFileName = System.currentTimeMillis() + "_" + fileName;
+
+                    String uploadDirName = "uploads";
+                    String uploadPath = getServletContext().getRealPath("") + File.separator + uploadDirName;
+
+                    File uploadDir = new File(uploadPath);
+                    if (!uploadDir.exists()) {
+                        uploadDir.mkdir();
+                    }
+
+                    filePart.write(uploadPath + File.separator + uniqueFileName);
+
+                    finalImageUrl = uploadDirName + "/" + uniqueFileName;
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Xảy ra lỗi trong quá trình bóc tách tệp tải lên: " + e.getMessage());
+        }
+
+        Product product = new Product();
+        product.setName(name);
+        product.setPrice(price);
+        product.setStock(stock);
+        product.setCategoryId(categoryId);
+        product.setFullDescription(fullDescription);
+        product.setStatus(status);
+        product.setFeatured(isFeatured);
+
+        ProductImage productImage = new ProductImage();
+        productImage.setImageUrl(finalImageUrl);
+        product.setImage(productImage);
+
+        ProductAttribute attribute = new ProductAttribute();
+        attribute.setMaterial(request.getParameter("material"));
+        attribute.setOrigin(request.getParameter("origin"));
+        attribute.setSize(request.getParameter("dimensions"));
+        attribute.setWeight(request.getParameter("weight"));
+        attribute.setColor(request.getParameter("manufacturer"));
+
+        if ("insert".equals(action)) {
+            productService.insertFullProduct(product, attribute, productImage);
+        } else if ("update".equals(action)) {
+            int id = Integer.parseInt(request.getParameter("id"));
+            product.setId(id);
+            productService.updateProduct(product, attribute, productImage);
+        }
+
+        response.sendRedirect(request.getContextPath() + "/admin/products");
+    }
+
 }

--- a/src/main/java/com/example/backend/dao/DashboardStatisticsDAO.java
+++ b/src/main/java/com/example/backend/dao/DashboardStatisticsDAO.java
@@ -1,0 +1,137 @@
+package com.example.backend.dao;
+
+import com.example.backend.model.Product;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.example.backend.util.DBConnection;
+
+public class DashboardStatisticsDAO {
+
+    public List<Product> getUnsoldProducts(String startDate, String endDate) {
+        List<Product> list = new ArrayList<>();
+        String sql = "SELECT id, name, stock, price FROM products " +
+                "WHERE id NOT IN (" +
+                "    SELECT DISTINCT oi.product_id FROM order_items oi " +
+                "    JOIN orders o ON oi.order_id = o.id " +
+                "    WHERE o.order_status = 'Hoàn thành' AND o.created_at BETWEEN ? AND ?" +
+                ") AND status = 'active'";
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, startDate + " 00:00:00");
+            ps.setString(2, endDate + " 23:59:59");
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Product p = new Product();
+                    p.setId(rs.getInt("id"));
+                    p.setName(rs.getString("name"));
+                    p.setStock(rs.getInt("stock"));
+                    p.setPrice(rs.getDouble("price"));
+                    list.add(p);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    public double getActualMonthlyRevenue() {
+        int currentMonth = LocalDate.now().getMonthValue();
+        int currentYear = LocalDate.now().getYear();
+        String sql = "SELECT SUM(total_amount) AS revenue FROM orders " +
+                "WHERE (order_status = 'Hoàn thành' OR order_status = 'completed') " +
+                "AND MONTH(created_at) = ? AND YEAR(created_at) = ?";
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, currentMonth);
+            ps.setInt(2, currentYear);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) return rs.getDouble("revenue");
+            }
+        } catch (Exception e) { e.printStackTrace(); }
+        return 0;
+    }
+
+    public List<Double> getRevenueDataByYear(int year) {
+        List<Double> monthlyRevenue = new ArrayList<>();
+        for (int i = 0; i < 12; i++) monthlyRevenue.add(0.0);
+
+        String sql = "SELECT MONTH(created_at) AS month, SUM(total_amount) AS total FROM orders " +
+                "WHERE (order_status = 'Hoàn thành' OR order_status = 'completed') AND YEAR(created_at) = ? " +
+                "GROUP BY MONTH(created_at)";
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, year);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int month = rs.getInt("month");
+                    double total = rs.getDouble("total");
+                    monthlyRevenue.set(month - 1, total);
+                }
+            }
+        } catch (Exception e) { e.printStackTrace(); }
+        return monthlyRevenue;
+    }
+
+    public double getRevenueByMonthAndYear(int month, int year) {
+        String sql = "SELECT SUM(total_amount) AS total FROM orders " +
+                "WHERE (order_status = 'Hoàn thành' OR order_status = 'completed') " +
+                "AND MONTH(created_at) = ? AND YEAR(created_at) = ?";
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, month);
+            ps.setInt(2, year);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) return rs.getDouble("total");
+            }
+        } catch (Exception e) { e.printStackTrace(); }
+        return 0;
+    }
+
+    public Map<String, Integer> getInventoryFlow(String startDate, String endDate) {
+        Map<String, Integer> flowData = new HashMap<>();
+        flowData.put("IMPORT", 0);
+        flowData.put("ADJUSTMENT", 0);
+        flowData.put("EXPORT", 0);
+
+        String sql = "SELECT transaction_type, SUM(ABS(quantity)) AS total_qty FROM inventory_transactions " +
+                "WHERE created_at BETWEEN ? AND ? GROUP BY transaction_type";
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, startDate + " 00:00:00");
+            ps.setString(2, endDate + " 23:59:59");
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    flowData.put(rs.getString("transaction_type"), rs.getInt("total_qty"));
+                }
+            }
+        } catch (Exception e) { e.printStackTrace(); }
+        return flowData;
+    }
+
+    public int getTotalImportedQuantity() {
+        String sql = "SELECT SUM(ABS(quantity)) AS total FROM inventory_transactions WHERE transaction_type = 'IMPORT'";
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) return rs.getInt("total");
+        } catch (Exception e) { e.printStackTrace(); }
+        return 0;
+    }
+
+    public int getTotalExportedQuantity() {
+        String sql = "SELECT SUM(ABS(quantity)) AS total FROM inventory_transactions WHERE transaction_type = 'EXPORT'";
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) return rs.getInt("total");
+        } catch (Exception e) { e.printStackTrace(); }
+        return 0;
+    }
+}

--- a/src/main/java/com/example/backend/dao/InventoryDao.java
+++ b/src/main/java/com/example/backend/dao/InventoryDao.java
@@ -1,0 +1,93 @@
+package com.example.backend.dao;
+
+import com.example.backend.model.Product;
+import com.example.backend.model.ProductImage;
+import com.example.backend.util.DBConnection;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InventoryDao {
+
+    public List<Product> getInventoryList() {
+        List<Product> list = new ArrayList<>();
+
+        String sql = "SELECT p.id, p.name, p.price, p.stock, p.sold_quantity AS totalSold " +
+                "FROM products p " +
+                "ORDER BY p.stock ASC, p.id DESC";
+
+        try (Connection conn = DBConnection.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+
+            while (rs.next()) {
+                Product p = new Product();
+                p.setId(rs.getInt("id"));
+                p.setName(rs.getString("name"));
+                p.setPrice(rs.getDouble("price"));
+                p.setStock(rs.getInt("stock"));
+                p.setTotalSold(rs.getInt("totalSold"));
+
+                ProductImage img = new ProductImage();
+                img.setImageUrl("admin/images/product-placeholder.png");
+                p.setImage(img);
+
+                list.add(p);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    public boolean importStockBatch(List<Integer> productIds, List<Integer> quantitiesAdded) {
+        // 👉 ĐÃ SỬA: Cập nhật trực tiếp vào cột stock vật lý của bảng products
+        String updateStockSql = "UPDATE products SET stock = stock + ? WHERE id = ?";
+        String insertTxSql = "INSERT INTO inventory_transactions (product_id, transaction_type, quantity, reason) VALUES (?, 'IMPORT', ?, 'Import hàng loạt tập trung')";
+
+        Connection conn = null;
+        PreparedStatement psUpdate = null;
+        PreparedStatement psTx = null;
+
+        try {
+            conn = DBConnection.getConnection();
+            conn.setAutoCommit(false);
+
+            psUpdate = conn.prepareStatement(updateStockSql);
+            psTx = conn.prepareStatement(insertTxSql);
+
+            for (int i = 0; i < productIds.size(); i++) {
+                int pId = productIds.get(i);
+                int qAdded = quantitiesAdded.get(i);
+
+                if (qAdded <= 0) continue;
+
+                psUpdate.setInt(1, qAdded);
+                psUpdate.setInt(2, pId);
+                psUpdate.addBatch();
+
+                psTx.setInt(1, pId);
+                psTx.setInt(2, qAdded);
+                psTx.addBatch();
+            }
+
+            psUpdate.executeBatch();
+            psTx.executeBatch();
+
+            conn.commit();
+            return true;
+        } catch (Exception e) {
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ex) { ex.printStackTrace(); }
+            }
+            e.printStackTrace();
+            return false;
+        } finally {
+            try {
+                if (psUpdate != null) psUpdate.close();
+                if (psTx != null) psTx.close();
+                if (conn != null) conn.close();
+            } catch (Exception e) { e.printStackTrace(); }
+        }
+    }
+}

--- a/src/main/java/com/example/backend/service/ProductService.java
+++ b/src/main/java/com/example/backend/service/ProductService.java
@@ -26,7 +26,7 @@ public class ProductService {
 
         productDAO.updateProductAttribute(product.getId(), attribute);
 
-        if (image.getImageUrl() != null && !image.getImageUrl().isEmpty()) {
+        if (image != null && image.getImageUrl() != null && !image.getImageUrl().isEmpty()) {
             productDAO.updateProductImage(product.getId(), image);
         }
     }
@@ -80,18 +80,17 @@ public class ProductService {
         return productDAO.getRelatedProducts(categoryId, currentProductId, 4);
     }
 
-    public void insertFullProduct(Product p, ProductAttribute pa) {
-        
+    public void insertFullProduct(Product p, ProductAttribute pa, ProductImage pi) {
         int productId = productDAO.insertProduct(p);
 
         if (productId > 0) {
-            
-            if (p.getImage() != null && p.getImage().getImageUrl() != null) {
-                productDAO.insertProductImage(productId, p.getImage().getImageUrl());
+            if (pi != null && pi.getImageUrl() != null && !pi.getImageUrl().isEmpty()) {
+                productDAO.insertProductImage(productId, pi.getImageUrl());
             }
 
-            
-            productDAO.insertProductAttributes(productId, pa);
+            if (pa != null) {
+                productDAO.insertProductAttributes(productId, pa);
+            }
         }
     }
 

--- a/src/main/webapp/admin/components/sidebar.jsp
+++ b/src/main/webapp/admin/components/sidebar.jsp
@@ -20,6 +20,10 @@
       <i class="fa-solid fa-box"></i> <span>Quản lý sản phẩm</span>
     </a>
 
+    <a href="${pageContext.request.contextPath}/admin/inventory"
+       class="admin-menu-item ${param.active == 'inventory' ? 'active' : ''}">
+      <i class="fa-solid fa-box"></i> <span>Quản lý tồn kho</span>
+    </a>
     
     <a href="${pageContext.request.contextPath}/admin/orders"
        class="admin-menu-item ${param.active == 'orders' ? 'active' : ''}">

--- a/src/main/webapp/admin/css/admin-home.css
+++ b/src/main/webapp/admin/css/admin-home.css
@@ -1,7 +1,3 @@
-
-
-
-
 .stats-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -71,16 +67,26 @@
 
 .dashboard-panels {
     display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+}
+
+.dashboard-panels-secondary {
+    display: grid;
     grid-template-columns: 2fr 1fr;
     gap: 24px;
+    margin-top: 20px;
 }
 
 .panel {
     background: var(--admin-surface);
     border: 1px solid var(--admin-border-subtle);
     border-radius: var(--admin-radius-lg);
-    padding: 20px;
+    padding: 25px;
     box-shadow: var(--admin-shadow-sm);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 }
 
 .panel-header {
@@ -97,8 +103,10 @@
     color: var(--admin-text-main);
 }
 
-.panel-header-spaced {
-    margin-top: 20px;
+.panel-header-line {
+    border-bottom: 1px solid var(--admin-border-subtle);
+    padding-bottom: 10px;
+    margin-bottom: 20px;
 }
 
 .activity-list {
@@ -159,12 +167,6 @@
     color: var(--admin-success);
 }
 
-.badge.muted {
-    background: var(--admin-surface-alt);
-    color: var(--admin-text-soft);
-    border: 1px solid var(--admin-border-subtle);
-}
-
 .action-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -203,46 +205,145 @@
     color: var(--admin-text-muted);
 }
 
-.summary-list {
+.analytics-form {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 15px;
+    margin: 0;
 }
 
-.summary-item {
+.compare-nodes-wrapper {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
-    padding: 12px;
-    border-radius: var(--admin-radius-md);
-    background: var(--admin-surface-alt);
+    gap: 10px;
 }
 
-.summary-item strong {
-    font-size: 14px;
+.compare-node {
+    flex: 1;
+    background: var(--admin-surface-alt);
+    padding: 10px;
+    border-radius: var(--admin-radius-md);
+    border-left: 4px solid var(--admin-border-strong);
+}
+
+.compare-node.node-a {
+    border-left-color: var(--admin-text-soft);
+}
+
+.compare-node.node-b {
+    border-left-color: var(--admin-accent);
+}
+
+.compare-node label {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 5px;
+    font-size: 13px;
+    color: var(--admin-text-muted);
+}
+
+.compare-node input[type="number"] {
+    padding: 4px;
+    border: 1px solid var(--admin-border-subtle);
+    border-radius: var(--admin-radius-sm);
+    background: var(--admin-surface);
     color: var(--admin-text-main);
 }
 
-.summary-item span {
-    font-size: 14px;
-    color: var(--admin-text-muted);
+.btn-analyze {
+    padding: 10px 20px;
+    width: 100%;
+    height: 40px;
+    border: none;
+    border-radius: var(--admin-radius-md);
     font-weight: 600;
+    cursor: pointer;
+    background: var(--admin-accent);
+    color: var(--admin-surface);
+    transition: background 0.2s;
+}
+
+.btn-analyze:hover {
+    opacity: 0.9;
+}
+
+.results-grid {
+    display: flex;
+    gap: 15px;
+    margin-top: 20px;
+    flex-wrap: wrap;
+}
+
+.result-box {
+    flex: 1;
+    background: var(--admin-surface-alt);
+    padding: 12px;
+    border-radius: var(--admin-radius-md);
+    text-align: center;
+}
+
+.result-box span {
+    color: var(--admin-text-muted);
+    font-size: 12px;
+    display: block;
+    margin-bottom: 5px;
+}
+
+.result-box h3 {
+    margin: 0;
+    color: var(--admin-text-main);
+    font-size: 18px;
+}
+
+.result-box.growth-positive {
+    background: var(--admin-success-soft);
+}
+
+.result-box.growth-negative {
+    background: var(--admin-warning-soft);
+}
+
+.chart-wrapper-square {
+    width: 100%;
+    height: 200px;
+    position: relative;
+    margin-top: auto;
+}
+
+.inventory-flow-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    flex-wrap: wrap;
+    gap: 30px;
+}
+
+.flow-chart-box {
+    width: 220px;
+    height: 220px;
+    position: relative;
+}
+
+.flow-details-list {
+    flex: 1;
+    min-width: 220px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.flow-details-list li {
+    margin-bottom: 12px;
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 1px dashed var(--admin-border-subtle);
+    padding-bottom: 6px;
+    font-size: 14px;
 }
 
 @media (max-width: 1024px) {
-    .dashboard-panels {
+    .dashboard-panels, .dashboard-panels-secondary {
         grid-template-columns: 1fr;
-    }
-}
-
-@media (max-width: 768px) {
-    .admin-dashboard-container {
-        padding: 20px;
-    }
-
-    .page-header {
-        flex-direction: column;
-        align-items: flex-start;
     }
 }

--- a/src/main/webapp/admin/css/admin-inventory.css
+++ b/src/main/webapp/admin/css/admin-inventory.css
@@ -1,0 +1,151 @@
+.inv-card {
+    background: var(--admin-surface);
+    border-radius: var(--admin-radius-md);
+    box-shadow: var(--admin-shadow-sm);
+    padding: 25px;
+    margin-top: 20px;
+    border: 1px solid var(--admin-border-subtle);
+}
+
+.inv-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+    margin-top: 15px;
+}
+
+.inv-table th {
+    background: #f8f9fa;
+    color: var(--admin-text-main);
+    padding: 12px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid var(--admin-border-strong);
+}
+
+.inv-table td {
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--admin-border-subtle);
+    font-size: 14px;
+    vertical-align: middle;
+}
+
+.p-info {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.badge-stock {
+    padding: 6px 12px;
+    border-radius: var(--admin-radius-sm);
+    font-size: 13px;
+    font-weight: 500;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.badge-stock.badge-danger {
+    background: #f1f2f6;
+    color: var(--admin-danger);
+    font-weight: bold;
+}
+
+.badge-stock.badge-warning {
+    background: #f1f2f6;
+    color: var(--admin-warning);
+}
+
+.badge-stock.badge-success {
+    background: #f1f2f6;
+    color: var(--admin-text-main);
+}
+
+.input-import {
+    width: 85px;
+    padding: 8px;
+    border: 1px solid var(--admin-border-strong);
+    border-radius: var(--admin-radius-sm);
+    text-align: center;
+    font-weight: 700;
+    color: var(--admin-text-main);
+    background: var(--admin-surface);
+    transition: all 0.2s ease-in-out;
+}
+
+.input-import:focus {
+    border-color: var(--admin-accent);
+    outline: none;
+    box-shadow: 0 0 0 3px var(--admin-accent-soft);
+}
+
+.import-td-bg {
+    text-align: center;
+    background: var(--admin-surface-alt) !important;
+}
+
+.btn-submit-inv {
+    background: #2563eb;
+    color: var(--admin-surface);
+    padding: 12px 24px;
+    border: none;
+    border-radius: var(--admin-radius-sm);
+    font-weight: 600;
+    cursor: pointer;
+    float: right;
+    margin-top: 20px;
+    box-shadow: var(--admin-shadow-sm);
+    transition: all 0.2s ease;
+}
+
+.btn-submit-inv:hover {
+    background: #1D4ED8;
+    box-shadow: var(--admin-shadow-md);
+}
+
+.alert-toast {
+    padding: 14px 20px;
+    border-radius: var(--admin-radius-sm);
+    margin-bottom: 15px;
+    font-weight: 500;
+    font-size: 14px;
+}
+
+.toast-success {
+    background: var(--admin-success-soft);
+    color: var(--admin-success);
+    border: 1px solid var(--admin-border-subtle);
+}
+
+.toast-error {
+    background: var(--admin-danger-soft);
+    color: var(--admin-danger);
+    border: 1px solid var(--admin-border-subtle);
+}
+
+.dataTables_wrapper .dataTables_filter {
+    margin-bottom: 20px;
+}
+
+.dataTables_wrapper .dataTables_filter input {
+    padding: 6px 12px;
+    border: 1px solid var(--admin-border-strong);
+    border-radius: var(--admin-radius-sm);
+    background: var(--admin-surface);
+    color: var(--admin-text-main);
+    margin-left: 8px;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current {
+    background: #2563eb !important;
+    color: white !important;
+    border-color: #2563eb !important;
+    border-radius: var(--admin-radius-sm) !important;
+}
+
+@media (max-width: 768px) {
+    .inv-card { padding: 15px; }
+    .btn-submit-inv { width: 100%; text-align: center; }
+}

--- a/src/main/webapp/admin/dashboard.jsp
+++ b/src/main/webapp/admin/dashboard.jsp
@@ -6,10 +6,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Bảng điều khiển</title>
+    <title>Bảng điều khiển Tổng quan</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/admin/css/admin-dashboard.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/admin/css/admin-home.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
 <main class="admin-dashboard-main">
@@ -25,12 +26,7 @@
                     <p>Theo dõi nhanh tình trạng cửa hàng</p>
                 </div>
                 <div class="header-right">
-                    <a href="${pageContext.request.contextPath}/" class="btn btn-secondary">
-                        <i class="fa-solid fa-globe"></i> Website
-                    </a>
-                    <a href="${pageContext.request.contextPath}/admin/products?action=new" class="btn btn-primary">
-                        <i class="fa-solid fa-plus"></i> Thêm sản phẩm
-                    </a>
+                    <a href="${pageContext.request.contextPath}/" class="btn btn-secondary" target="_blank"><i class="fa-solid fa-globe"></i> Website</a>
                 </div>
             </div>
 
@@ -42,19 +38,15 @@
                     </div>
                     <div class="stat-value">${totalProducts}</div>
                     <div class="stat-label">Tổng số sản phẩm</div>
-                    <div class="stat-meta">Cập nhật gần nhất: hôm nay</div>
                 </div>
-
                 <div class="stat-card">
                     <div class="stat-header">
                         <div class="stat-icon"><i class="fa-solid fa-cart-shopping"></i></div>
                         <span class="badge info">Đơn hàng</span>
                     </div>
                     <div class="stat-value">${ordersToday}</div>
-                    <div class="stat-label">Đơn hàng hôm nay</div>
-                    <div class="stat-meta">Chưa có dữ liệu đồng bộ</div>
+                    <div class="stat-label">Tổng số đơn hàng</div>
                 </div>
-
                 <div class="stat-card">
                     <div class="stat-header">
                         <div class="stat-icon warning"><i class="fa-solid fa-clock"></i></div>
@@ -62,51 +54,133 @@
                     </div>
                     <div class="stat-value">${pendingOrders}</div>
                     <div class="stat-label">Đơn chờ xác nhận</div>
-                    <div class="stat-meta">Theo dõi trạng thái mới</div>
                 </div>
-
                 <div class="stat-card">
                     <div class="stat-header">
                         <div class="stat-icon success"><i class="fa-solid fa-sack-dollar"></i></div>
                         <span class="badge success">Doanh thu</span>
                     </div>
-                    <div class="stat-value"><fmt:formatNumber value="${monthlyRevenue}" type="currency" currencySymbol="đ" /></div>
-                    <div class="stat-label">Doanh thu tháng</div>
-                    <div class="stat-meta">Chưa có báo cáo</div>
+                    <div class="stat-value" style="color: #2ecc71;"><fmt:formatNumber value="${monthlyRevenue}" type="currency" currencySymbol="đ" /></div>
+                    <div class="stat-label">Doanh thu tháng này</div>
                 </div>
             </section>
 
-            <section class="dashboard-panels">
+            <section class="dashboard-panels" style="margin-top: 20px;">
+
+                <div class="panel">
+                    <div>
+                        <div class="panel-header panel-header-line">
+                            <h2>Bộ phân tích đối chiếu doanh thu</h2>
+                        </div>
+                        <form action="${pageContext.request.contextPath}/admin/dashboard" method="get" class="analytics-form">
+                            <div class="compare-nodes-wrapper">
+                                <div class="compare-node node-a">
+                                    <label>Mốc đối chiếu A:</label>
+                                    Tháng <input type="number" name="monthA" value="${mA}" min="1" max="12">
+                                    Năm <input type="number" name="yearA" value="${yA}">
+                                </div>
+                                <div style="font-size: 1.2rem; color: #95a5a6;"><i class="fa-solid fa-arrow-right-arrow-left"></i></div>
+                                <div class="compare-node node-b">
+                                    <label>Mốc đối chiếu B:</label>
+                                    Tháng <input type="number" name="monthB" value="${mB}" min="1" max="12">
+                                    Năm <input type="number" name="yearB" value="${yB}">
+                                </div>
+                            </div>
+                            <button type="submit" class="btn-analyze">Tính toán & Vẽ lại biểu đồ</button>
+                        </form>
+                    </div>
+
+                    <div class="results-grid">
+                        <div class="result-box">
+                            <span>Doanh thu trước</span>
+                            <h3><fmt:formatNumber value="${revenueMocA}" type="currency" currencySymbol="đ"/></h3>
+                        </div>
+                        <div class="result-box" style="background: #e3f2fd;">
+                            <span style="color: #1e88e5;">Doanh thu sau</span>
+                            <h3 style="color: #1565c0;"><fmt:formatNumber value="${revenueMocB}" type="currency" currencySymbol="đ"/></h3>
+                        </div>
+                        <div class="result-box ${comparisonGrowth >= 0 ? 'growth-positive' : 'growth-negative'}">
+                            <span>Biến động</span>
+                            <strong style="font-size: 1.2rem; color: ${comparisonGrowth >= 0 ? '#2e7d32' : '#c62828'};">
+                                ${comparisonGrowth >= 0 ? '+' : '-'}${comparisonGrowth}%
+                            </strong>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="panel">
+                    <div class="panel-header" style="border-bottom: 1px solid #eee; padding-bottom: 10px; margin-bottom: 15px;">
+                        <h2>Trực quan hóa dữ liệu</h2>
+                    </div>
+                    <div class="chart-wrapper-square">
+                        <canvas id="comparisonChart"></canvas>
+                    </div>
+                </div>
+
+            </section>
+
+            <section class="dashboard-panels" style="margin-top: 20px; grid-template-columns: 1fr;">
+                <div class="panel">
+                    <div class="panel-header panel-header-line">
+                        <h2><i class="fa-solid fa-chart-pie" style="color: #e67e22;"></i> Thống kê nhập/xuất & Hiệu suất bán hàng</h2>
+                    </div>
+                    <div class="inventory-flow-container">
+                        <div class="flow-chart-box">
+                            <canvas id="flowChart"></canvas>
+                        </div>
+
+                        <div class="flow-details" style="flex: 1; min-width: 220px;">
+                            <ul class="flow-details-list">
+                                <li>
+                                    <span><i class="fa-solid fa-box-open" style="color: #2ecc71; margin-right: 5px;"></i> Tổng đã nhập kho (Lịch sử):</span>
+                                    <strong style="color: #2ecc71;">${totalAllImport} cái</strong>
+                                </li>
+                                <li>
+                                    <span><i class="fa-solid fa-truck-loading" style="color: #3498db; margin-right: 5px;"></i> Tổng đã xuất bán (Lịch sử):</span>
+                                    <strong style="color: #3498db;">${totalAllExport} cái</strong>
+                                </li>
+                                <li>
+                                    <span><i class="fa-solid fa-square-minus" style="color: #e74c3c; margin-right: 5px;"></i> Tổng hao hụt / lỗi hỏng (Theo lịch lọc):</span>
+                                    <strong style="color: #e74c3c;">${not empty invFlow['ADJUSTMENT'] ? invFlow['ADJUSTMENT'] : 0} cái</strong>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div class="kpi-box" style="flex: 1; min-width: 200px; background: #f8f9fa; border-radius: 8px; padding: 20px; text-align: center; border: 1px solid #e2e8f0; display: flex; flex-direction: column; justify-content: center; align-items: center;">
+                            <span style="font-size: 13px; color: #4a5568; font-weight: 600; margin-bottom: 8px;">Tỷ lệ Bán ra / Nhập vào</span>
+                            <div style="font-size: 2rem; font-weight: 800; color: #2b6cb0;">${salesToImportRatio}%</div>
+                            <p style="font-size: 12px; color: #718096; margin-top: 6px; line-height: 1.4;">
+                                <c:choose>
+                                    <c:when test="${salesToImportRatio >= 70}">Hiệu suất bán hàng xuất sắc! Tốc độ đẩy hàng nhanh.</c:when>
+                                    <c:when test="${salesToImportRatio >= 40}">Tốc độ bán hàng ổn định, dòng vốn lưu thông tốt.</c:when>
+                                    <c:otherwise>Cảnh báo: Tỷ lệ lưu kho cao, cân nhắc giảm giá để giải phóng hàng.</c:otherwise>
+                                </c:choose>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <section class="dashboard-panels-secondary">
                 <div class="panel">
                     <div class="panel-header">
                         <h2>Hoạt động gần đây</h2>
-                        <a href="${pageContext.request.contextPath}/admin/products" class="btn btn-ghost">
-                            Xem sản phẩm
-                        </a>
                     </div>
                     <div class="activity-list">
                         <c:forEach var="order" items="${recentOrders}">
                             <div class="activity-item">
                                 <div>
                                     <p class="activity-title">Đơn hàng #${order.id} - ${order.shipping_name}</p>
-                                    <span class="activity-time">
-                        <fmt:formatDate value="${order.created_at}" pattern="dd/MM/yyyy HH:mm"/>
-                    </span>
+                                    <span class="activity-time"><fmt:formatDate value="${order.created_at}" pattern="dd/MM/yyyy HH:mm"/></span>
                                 </div>
-                                <c:choose>
-                                    <c:when test="${order.order_status == 'pending'}">
-                                        <span class="badge warning">Chờ xử lý</span>
-                                    </c:when>
-                                    <c:when test="${order.order_status == 'completed'}">
-                                        <span class="badge success">Hoàn tất</span>
-                                    </c:when>
-                                    <c:otherwise>
-                                        <span class="badge info">${order.order_status}</span>
-                                    </c:otherwise>
-                                </c:choose>
+                                <span class="badge ${order.order_status == 'pending' ? 'warning' : 'success'}">
+                                    <c:choose>
+                                        <c:when test="${order.order_status == 'pending'}">Chờ xử lý</c:when>
+                                        <c:when test="${order.order_status == 'completed'}">Hoàn tất</c:when>
+                                        <c:otherwise>${order.order_status}</c:otherwise>
+                                    </c:choose>
+                                </span>
                             </div>
                         </c:forEach>
-
                         <c:if test="${empty recentOrders}">
                             <div class="activity-item">
                                 <p class="activity-title">Chưa có đơn hàng nào mới</p>
@@ -116,35 +190,72 @@
                 </div>
 
                 <div class="panel">
-                    <div class="panel-header">
-                        <h2>Lối tắt</h2>
-                    </div>
+                    <div class="panel-header"><h2>Lối tắt quản lý</h2></div>
                     <div class="action-grid">
-                        <a class="action-card" href="${pageContext.request.contextPath}/admin/products?action=new">
-                            <i class="fa-solid fa-plus"></i>
-                            <strong>Thêm sản phẩm</strong>
-                            <span>Tạo sản phẩm mới</span>
-                        </a>
-                        <a class="action-card" href="${pageContext.request.contextPath}/admin/orders/order-list.jsp">
-                            <i class="fa-solid fa-shopping-cart"></i>
-                            <strong>Danh sách đơn hàng</strong>
-                            <span>Theo dõi giao dịch</span>
-                        </a>
-                        <a class="action-card" href="${pageContext.request.contextPath}/admin/products">
-                            <i class="fa-solid fa-box"></i>
-                            <strong>Danh sách sản phẩm</strong>
-                            <span>Quản lý hàng hóa</span>
-                        </a>
-                        <a class="action-card" href="${pageContext.request.contextPath}/admin/customers">
-                            <i class="fa-solid fa-users"></i>
-                            <strong>Danh sách khách hàng</strong>
-                            <span>Quay lại khách hàng</span>
-                        </a>
+                        <a class="action-card" href="${pageContext.request.contextPath}/admin/products?action=new"><i class="fa-solid fa-plus"></i><strong>Thêm sản phẩm</strong><span>Tạo sản phẩm mới</span></a>
+                        <a class="action-card" href="${pageContext.request.contextPath}/admin/orders/order-list.jsp"><i class="fa-solid fa-shopping-cart"></i><strong>Danh sách đơn hàng</strong><span>Theo dõi giao dịch</span></a>
+                        <a class="action-card" href="${pageContext.request.contextPath}/admin/products"><i class="fa-solid fa-box"></i><strong>Danh sách sản phẩm</strong><span>Quản lý hàng hóa</span></a>
+                        <a class="action-card" href="${pageContext.request.contextPath}/admin/customers"><i class="fa-solid fa-users"></i><strong>Danh sách khách hàng</strong><span>Quản lý người dùng</span></a>
                     </div>
                 </div>
             </section>
         </div>
     </div>
 </main>
+
+<script>
+    const compCtx = document.getElementById('comparisonChart').getContext('2d');
+    new Chart(compCtx, {
+        type: 'bar',
+        data: {
+            labels: ['Tháng ${mA}/${yA}', 'Tháng ${mB}/${yB}'],
+            datasets: [{
+                label: 'Doanh thu thu được',
+                data: [${revenueMocA}, ${revenueMocB}],
+                backgroundColor: ['#bdc3c7', '#3498db'],
+                borderWidth: 1,
+                borderRadius: 4,
+                barPercentage: 0.5
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: { callback: value => value.toLocaleString('vi-VN') + 'đ' }
+                }
+            }
+        }
+    });
+
+    const flowCtx = document.getElementById('flowChart').getContext('2d');
+    new Chart(flowCtx, {
+        type: 'doughnut',
+        data: {
+            labels: ['Nhập kho', 'Hao hụt lỗi', 'Xuất bán'],
+            datasets: [{
+                data: [
+                    ${not empty invFlow['IMPORT'] ? invFlow['IMPORT'] : 0},
+                    ${not empty invFlow['ADJUSTMENT'] ? invFlow['ADJUSTMENT'] : 0},
+                    ${not empty invFlow['EXPORT'] ? invFlow['EXPORT'] : 0}
+                ],
+                backgroundColor: ['#2ecc71', '#e74c3c', '#3498db'],
+                borderWidth: 2
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false }
+            }
+        }
+    });
+</script>
 </body>
 </html>

--- a/src/main/webapp/admin/inventory/inventory-list.jsp
+++ b/src/main/webapp/admin/inventory/inventory-list.jsp
@@ -1,0 +1,134 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <title>Quản lý tồn kho</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/admin/css/admin-dashboard.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/admin/css/admin-inventory.css">
+
+    <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
+</head>
+<body>
+<div class="admin-dashboard-container">
+    <jsp:include page="/admin/components/sidebar.jsp">
+        <jsp:param name="active" value="inventory" />
+    </jsp:include>
+
+    <div class="admin-content">
+        <div class="page-header">
+            <div class="header-left">
+                <h1>Quản lý kho hàng tập trung</h1>
+                <p>Hệ thống hỗ trợ phân trang và tìm kiếm thông minh. Dữ liệu nhập thêm sẽ được giữ nguyên khi chuyển trang.</p>
+            </div>
+        </div>
+
+        <div class="inv-card">
+            <c:if test="${param.status == 'success'}">
+                <div class="alert-toast toast-success">Đã import cộng dồn số lượng tồn kho mới vào hệ thống thành công!</div>
+            </c:if>
+            <c:if test="${param.status == 'error'}">
+                <div class="alert-toast toast-error">Quá trình kết nối hoặc import thất bại. Vui lòng kiểm tra lại cấu trúc DB!</div>
+            </c:if>
+
+            <form id="inventoryForm" action="${pageContext.request.contextPath}/admin/inventory" method="post">
+                <table class="inv-table" id="inventoryTable">
+                    <thead>
+                    <tr>
+                        <th style="width: 50px;">ID</th>
+                        <th>TÊN SẢN PHẨM</th>
+                        <th style="text-align: center;">ĐƠN GIÁ</th>
+                        <th style="text-align: center;">TỒN KHO</th>
+                        <th style="text-align: center;">ĐÃ BÁN</th>
+                        <th style="text-align: center; width: 150px;">NHẬP THÊM</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <c:forEach var="p" items="${inventoryList}">
+                        <tr>
+                            <td><strong>#${p.id}</strong></td>
+                            <td>
+                                <div class="p-info">
+                                    <span style="font-weight: 600; color: var(--admin-text-main);">${p.name}</span>
+                                </div>
+                            </td>
+                            <td style="text-align: center; font-weight: 500; color: var(--admin-text-muted);">
+                                <fmt:setLocale value="vi_VN"/>
+                                <fmt:formatNumber value="${p.price}" type="currency" currencySymbol="đ"/>
+                            </td>
+
+                            <td style="text-align: center;">
+                                <c:choose>
+                                    <c:when test="${p.stock == 0}">
+                                        <span class="badge-stock badge-danger">Hết hàng (0)</span>
+                                    </c:when>
+                                    <c:when test="${p.stock <= 10}">
+                                        <span class="badge-stock badge-warning">Sắp hết (${p.stock})</span>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <span class="badge-stock badge-success">Còn hàng (${p.stock})</span>
+                                    </c:otherwise>
+                                </c:choose>
+                            </td>
+
+                            <td style="text-align: center; font-weight: 700; color: var(--admin-text-main); font-size: 15px;">
+                                    ${p.totalSold} cái
+                            </td>
+
+                            <td class="import-td-bg">
+                                <input type="hidden" name="productIds" value="${p.id}">
+                                <input type="number" name="stockAdds" min="0" placeholder="+" class="input-import">
+                            </td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+
+                <button type="submit" class="btn-submit-inv">Xác nhận Import kho hàng loạt</button>
+                <div style="clear: both;"></div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function() {
+        const vietnameseLanguage = {
+            "sProcessing": "Đang xử lý...", "sLengthMenu": "Xem _MENU_ mục", "sZeroRecords": "Không tìm thấy dòng nào phù hợp",
+            "sInfo": "Đang xem _START_ đến _END_ trong tổng số _TOTAL_ mục", "sInfoEmpty": "Đang xem 0 đến 0 trong tổng số 0 mục",
+            "sSearch": "Tìm kiếm nhanh sản phẩm:",
+            "oPaginate": { "sFirst": "Đầu", "sPrevious": "Trước", "sNext": "Tiếp", "sLast": "Cuối" }
+        };
+
+        const table = $('#inventoryTable').DataTable({
+            "language": vietnameseLanguage,
+            "pageLength": 10,
+            "order": [[0, 'desc']],
+            "columnDefs": [
+                { "orderable": false, "targets": [1, 5] }
+            ]
+        });
+
+        $('#inventoryForm').on('submit', function(e) {
+            const form = this;
+            table.$('input').each(function() {
+                if (!$.contains(document, this)) {
+                    $(form).append(
+                        $('<input>')
+                            .attr('type', 'hidden')
+                            .attr('name', this.name)
+                            .val($(this).val())
+                    );
+                }
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/src/main/webapp/admin/orders/order-detail.jsp
+++ b/src/main/webapp/admin/orders/order-detail.jsp
@@ -17,56 +17,10 @@
 <body>
 <main class="admin-dashboard-main">
     <div class="admin-dashboard-container">
-        
-        <aside class="admin-sidebar">
-            <div class="sidebar-header">
-                <div class="admin-logo">
-                    <i class="fa-solid fa-user-shield"></i>
-                </div>
-                <h2>Bảng quản lý Website</h2>
-                <p>Quản trị viên</p>
-            </div>
 
-            <nav class="admin-menu">
-                <a href="${pageContext.request.contextPath}/admin/dashboard" class="admin-menu-item">
-                    <i class="fa-solid fa-chart-line"></i>
-                    <span>Bảng điều khiển</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/products" class="admin-menu-item">
-                    <i class="fa-solid fa-box"></i>
-                    <span>Quản lý sản phẩm</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/order-list.jsp" class="admin-menu-item active">
-                    <i class="fa-solid fa-shopping-cart"></i>
-                    <span>Quản lý đơn hàng</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/customers" class="admin-menu-item">
-                    <i class="fa-solid fa-users"></i>
-                    <span>Quản lý khách hàng</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/reviews" class="admin-menu-item">
-                    <i class="fa-solid fa-star"></i>
-                    <span>Quản lý đánh giá</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/categories" class="admin-menu-item">
-                    <i class="fa-solid fa-folder-tree"></i>
-                    <span>Quản lý danh mục</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/contact" class="admin-menu-item">
-                    <i class="fa-solid fa-envelope"></i>
-                    <span>Quản lý liên hệ</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/blog" class="admin-menu-item">
-                    <i class="fa-solid fa-blog"></i>
-                    <span>Blog</span>
-                </a>
-                <a href="${pageContext.request.contextPath}/admin/banner" class="admin-menu-item">
-                    <i class="fa-solid fa-images"></i>
-                    <span>Banner & Slider</span>
-                </a>
-            </nav>
-        </aside>
-
+        <jsp:include page="/admin/components/sidebar.jsp">
+            <jsp:param name="active" value="orders" />
+        </jsp:include>
         
         <div class="admin-content">
             

--- a/src/main/webapp/admin/orders/order-list.jsp
+++ b/src/main/webapp/admin/orders/order-list.jsp
@@ -1,6 +1,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="jakarta.tags.core" %>
-<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <!DOCTYPE html>
 <html lang="vi">
 <head>
@@ -10,259 +11,120 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/admin/css/admin-dashboard.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/admin/css/orders-list.css">
+    <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
 </head>
 <body>
-    <fmt:setLocale value="vi_VN"/>
-    <main class="admin-dashboard-main">
-        <div class="admin-dashboard-container">
-            <jsp:include page="/admin/components/sidebar.jsp">
-                <jsp:param name="active" value="orders" />
-            </jsp:include>
+<fmt:setLocale value="vi_VN"/>
+<main class="admin-dashboard-main">
+    <div class="admin-dashboard-container">
+        <jsp:include page="/admin/components/sidebar.jsp">
+            <jsp:param name="active" value="orders" />
+        </jsp:include>
 
-            
-            <div class="admin-content">
-                
-                <div class="page-header">
-                    <div class="header-left">
-                        <h1>Quản lý đơn hàng</h1>
-                        <p>Tổng cộng <strong>${orders != null ? orders.size() : 0} đơn hàng</strong></p>
-                    </div>
-                    <div class="header-right">
-                        <button class="btn-export-excel">
-                            <i class="fa-solid fa-file-excel"></i>
-                            Xuất Excel
-                        </button>
-                        <button class="btn-export-pdf">
-                            <i class="fa-solid fa-file-pdf"></i>
-                            Xuất PDF
-                        </button>
-                    </div>
-                </div>
-
-                
-                <div class="status-tabs">
-                    <a href="#" class="tab-item active">
-                        <span class="tab-label">Tất cả</span>
-                    </a>
-                    <a href="#" class="tab-item pending">
-                        <span class="tab-label">Chờ xác nhận</span>
-                    </a>
-                    <a href="#" class="tab-item confirmed">
-                        <span class="tab-label">Đã xác nhận</span>
-                    </a>
-                    <a href="#" class="tab-item shipping">
-                        <span class="tab-label">Đang giao</span>
-                    </a>
-                    <a href="#" class="tab-item completed">
-                        <span class="tab-label">Hoàn thành</span>
-                    </a>
-                    <a href="#" class="tab-item cancelled">
-                        <span class="tab-label">Đã hủy</span>
-                    </a>
-                    <a href="#" class="tab-item returned">
-                        <span class="tab-label">Hoàn trả</span>
-                    </a>
-                </div>
-
-                
-                <div class="filter-section">
-                    <form action="${pageContext.request.contextPath}/admin/orders" method="get" class="filter-form">
-                        
-                        <div class="search-wrapper">
-                            <i class="fa-solid fa-search"></i>
-                            <input type="text" name="search" value="${param.search}" placeholder="Tìm kiếm theo mã đơn hàng, tên khách hàng, SĐT, email..." class="search-input">
-                        </div>
-
-                        
-                        <div class="filter-options">
-                            
-                            <div class="filter-group">
-                                <label for="date-from">
-                                    <i class="fa-solid fa-calendar"></i>
-                                    Từ ngày
-                                </label>
-                                <input type="date" id="date-from" name="date_from">
-                            </div>
-
-                            <div class="filter-group">
-                                <label for="date-to">
-                                    <i class="fa-solid fa-calendar"></i>
-                                    Đến ngày
-                                </label>
-                                <input type="date" id="date-to" name="date_to">
-                            </div>
-
-                            
-                            <div class="filter-group">
-                                <label for="order-value">
-                                    <i class="fa-solid fa-dollar-sign"></i>
-                                    Giá trị đơn hàng
-                                </label>
-                                <select name="order_value" id="order-value">
-                                    <option value="">Tất cả</option>
-                                    <option value="0-500000">Dưới 500K</option>
-                                    <option value="500000-1000000">500K - 1M</option>
-                                    <option value="1000000-2000000">1M - 2M</option>
-                                    <option value="2000000-5000000">2M - 5M</option>
-                                    <option value="5000000+">Trên 5M</option>
-                                </select>
-                            </div>
-
-                            
-                            <div class="filter-group">
-                                <label for="payment-method">
-                                    <i class="fa-solid fa-credit-card"></i>
-                                    Phương thức thanh toán
-                                </label>
-                                <select name="payment_method" id="payment-method">
-                                    <option value="">Tất cả</option>
-                                    <option value="cod">Tiền mặt</option>
-                                    <option value="momo">Ví MoMo</option>
-                                    <option value="vnpay">VNPay</option>
-                                </select>
-                            </div>
-
-                            
-                            <div class="filter-group">
-                                <label for="payment-status">
-                                    <i class="fa-solid fa-money-check"></i>
-                                    Trạng thái thanh toán
-                                </label>
-                                <select name="payment_status" id="payment-status">
-                                    <option value="">Tất cả</option>
-                                    <option value="paid">Đã thanh toán</option>
-                                    <option value="unpaid">Chưa thanh toán</option>
-                                    <option value="refunded">Đã hoàn tiền</option>
-                                </select>
-                            </div>
-                        </div>
-
-                        
-                        <div class="filter-actions">
-                            <button type="submit" class="btn-apply-filter">
-                                <i class="fa-solid fa-filter"></i>
-                                Áp dụng
-                            </button>
-                            <button type="reset" class="btn-reset-filter">
-                                <i class="fa-solid fa-rotate-right"></i>
-                                Đặt lại
-                            </button>
-                        </div>
-                    </form>
-                </div>
-
-                <div class="orders-table-container">
-                    <table class="orders-table">
-                        <thead>
-                        <tr>
-                            <th class="col-order-id">MÃ ĐƠN HÀNG</th>
-                            <th class="col-customer">KHÁCH HÀNG / LIÊN HỆ</th>
-                            <th class="col-total">TỔNG TIỀN</th>
-                            <th class="col-payment">THANH TOÁN</th>
-                            <th class="col-payment-status">TT THANH TOÁN</th>
-                            <th class="col-date">NGÀY ĐẶT</th>
-                            <th class="col-status">TRẠNG THÁI</th>
-                            <th class="col-actions">THAO TÁC</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        <c:forEach var="o" items="${orders}">
-                            <tr class="order-row">
-                                <td class="col-order-id">
-                                    <a href="orders?action=detail&id=${o.id}" class="order-id-link">#DH${o.id}</a>
-                                </td>
-
-                                <td class="col-customer">
-                                    <div class="customer-info-box">
-                                        <div class="customer-main">
-                                            <i class="fa-solid fa-circle-user"></i>
-                                            <strong>${o.shipping_name}</strong>
-                                        </div>
-                                        <div class="customer-sub">
-                                            <span><i class="fa-solid fa-phone"></i> ${o.shipping_phone}</span>
-                                        </div>
-                                    </div>
-                                </td>
-
-                                <td class="col-total">
-                        <span class="total-amount">
-                            <fmt:formatNumber value="${o.total_amount}" pattern="#,###"/>₫
-                        </span>
-                                </td>
-
-                                <td class="col-payment">
-                                    <span class="payment-badge cod">COD</span>
-                                </td>
-
-                                <td class="col-payment-status">
-                        <span class="status-text ${o.order_status == 'Pending' ? 'text-unpaid' : 'text-paid'}">
-                                ${o.order_status == 'Pending' ? 'Chưa TT' : 'Đã TT'}
-                        </span>
-                                </td>
-
-                                <td class="col-date">
-                                    <div class="date-info">
-                                        <p><fmt:formatDate value="${o.created_at}" pattern="dd/MM/yyyy"/></p>
-                                        <small><fmt:formatDate value="${o.created_at}" pattern="HH:mm"/></small>
-                                    </div>
-                                </td>
-
-                                <td class="col-status">
-                        <span class="status-badge status-${o.order_status.toLowerCase()}">
-                                ${o.order_status}
-                        </span>
-                                </td>
-
-                                <td class="col-actions">
-                                    <div class="action-buttons">
-                                        <a href="orders?action=detail&id=${o.id}" class="btn-action btn-view" title="Xem">
-                                            <i class="fa-solid fa-eye"></i>
-                                        </a>
-                                        <button class="btn-action btn-print" title="In" onclick="window.print()">
-                                            <i class="fa-solid fa-print"></i>
-                                        </button>
-                                    </div>
-                                </td>
-                            </tr>
-                        </c:forEach>
-                        </tbody>
-                    </table>
-                </div>
-
-                <div class="pagination-section">
-                    <div class="pagination-info">
-                        
-                        Hiển thị <strong>1 - ${orders.size()}</strong> trong tổng số <strong>${totalOrders != null ? totalOrders : orders.size()}</strong> đơn hàng
-                    </div>
-
-                    <div class="pagination">
-                        
-                        <a href="orders?action=list&page=${currentPage - 1}" class="page-link ${currentPage <= 1 ? 'disabled' : ''}">
-                            <i class="fa-solid fa-chevron-left"></i>
-                        </a>
-
-                        
-                        <c:forEach begin="1" end="${totalPages}" var="i">
-                            <a href="orders?action=list&page=${i}" class="page-link ${i == currentPage ? 'active' : ''}">${i}</a>
-                        </c:forEach>
-
-                        
-                        <a href="orders?action=list&page=${currentPage + 1}" class="page-link ${currentPage >= totalPages ? 'disabled' : ''}">
-                            <i class="fa-solid fa-chevron-right"></i>
-                        </a>
-                    </div>
-
-                    <div class="per-page">
-                        <label for="per-page">Hiển thị:</label>
-                        <select name="per_page" id="per-page" onchange="window.location.href='orders?action=list&pageSize=' + this.value">
-                            <option value="8" ${pageSize == 8 ? 'selected' : ''}>8</option>
-                            <option value="20" ${pageSize == 20 ? 'selected' : ''}>20</option>
-                            <option value="50" ${pageSize == 50 ? 'selected' : ''}>50</option>
-                        </select>
-                    </div>
+        <div class="admin-content">
+            <div class="page-header">
+                <div class="header-left">
+                    <h1>Quản lý đơn hàng</h1>
+                    <p>Tổng cộng <strong id="order-count-label">${orders != null ? orders.size() : 0} đơn hàng</strong></p>
                 </div>
             </div>
+
+            <div class="status-tabs">
+                <a href="#" class="tab-item active" data-status="all"><span class="tab-label">Tất cả</span></a>
+                <a href="#" class="tab-item pending" data-status="pending"><span class="tab-label">Chờ xác nhận</span></a>
+                <a href="#" class="tab-item completed" data-status="completed"><span class="tab-label">Hoàn thành</span></a>
+            </div>
+
+            <div class="orders-table-container" style="margin-top: 20px;">
+                <table class="orders-table" id="adminOrderTable">
+                    <thead>
+                    <tr>
+                        <th class="col-order-id">MÃ ĐƠN HÀNG</th>
+                        <th class="col-customer">KHÁCH HÀNG / LIÊN HỆ</th>
+                        <th class="col-total">TỔNG TIỀN</th>
+                        <th class="col-payment">THANH TOÁN</th>
+                        <th class="col-payment-status">TT THANH TOÁN</th>
+                        <th class="col-date">NGÀY ĐẶT</th>
+                        <th class="col-status">TRẠNG THÁI</th>
+                        <th class="col-actions">THAO TÁC</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <c:forEach var="o" items="${orders}">
+                        <tr class="order-row" data-status="${fn:toLowerCase(o.order_status)}">
+                            <td class="col-order-id">
+                                <a href="orders?action=detail&id=${o.id}" class="order-id-link">#DH${o.id}</a>
+                            </td>
+                            <td class="col-customer">
+                                <div class="customer-info-box">
+                                    <div class="customer-main">
+                                        <i class="fa-solid fa-circle-user"></i>
+                                        <strong>${o.shipping_name}</strong>
+                                    </div>
+                                    <div class="customer-sub">
+                                        <span><i class="fa-solid fa-phone"></i> ${o.shipping_phone}</span>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="col-total">
+                                    <span class="total-amount">
+                                        <fmt:formatNumber value="${o.total_amount}" pattern="#,###"/>₫
+                                    </span>
+                            </td>
+                            <td class="col-payment"><span class="payment-badge cod">COD</span></td>
+                            <td class="col-payment-status">
+                                    <span class="status-text ${fn:toLowerCase(o.order_status) == 'pending' ? 'text-unpaid' : 'text-paid'}">
+                                            ${fn:toLowerCase(o.order_status) == 'pending' ? 'Chưa TT' : 'Đã TT'}
+                                    </span>
+                            </td>
+                            <td class="col-date">
+                                <div class="date-info">
+                                    <p><fmt:formatDate value="${o.created_at}" pattern="dd/MM/yyyy"/></p>
+                                    <small><fmt:formatDate value="${o.created_at}" pattern="HH:mm"/></small>
+                                </div>
+                            </td>
+                            <td class="col-status">
+                                    <span class="badge ${fn:toLowerCase(o.order_status) == 'pending' ? 'warning' : 'success'}">
+                                            ${o.order_status}
+                                    </span>
+                            </td>
+                            <td class="col-actions">
+                                <div class="action-buttons">
+                                    <a href="orders?action=detail&id=${o.id}" class="btn-action btn-view" title="Xem"><i class="fa-solid fa-eye"></i></a>
+                                </div>
+                            </td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+            </div>
         </div>
-    </main>
+    </div>
+</main>
+
+<script>
+    $(document).ready(function() {
+        $('.tab-item').on('click', function(e) {
+            e.preventDefault();
+            $('.tab-item').removeClass('active');
+            $(this).addClass('active');
+
+            const targetStatus = $(this).data('status');
+            let visibleCount = 0;
+
+            $('.order-row').each(function() {
+                const rowStatus = $(this).data('status');
+                if (targetStatus === 'all' || rowStatus === targetStatus) {
+                    $(this).show();
+                    visibleCount++;
+                } else {
+                    $(this).hide();
+                }
+            });
+
+            $('#order-count-label').text(visibleCount + " đơn hàng");
+        });
+    });
+</script>
 </body>
 </html>

--- a/src/main/webapp/admin/products/product-list.jsp
+++ b/src/main/webapp/admin/products/product-list.jsp
@@ -1,6 +1,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 
 <!DOCTYPE html>
 <html lang="vi">
@@ -36,6 +37,25 @@
                 </div>
             </div>
 
+            <c:if test="${not empty outOfStockProducts}">
+                <div style="background: #fff5f5; border-left: 5px solid #e53e3e; padding: 15px; margin-bottom: 20px; border-radius: 6px;">
+                    <h3 style="color: #c53030; margin: 0 0 8px 0; font-size: 15px;"><i class="fa-solid fa-triangle-exclamation"></i> Phát hiện (${fn:length(outOfStockProducts)}) mặt hàng đã hết kho:</h3>
+                    <div style="display: flex; flex-wrap: wrap; gap: 8px;">
+                        <c:forEach var="outItem" items="${outOfStockProducts}">
+                            <span style="background: #fed7d7; color: #9b2c2c; padding: 3px 8px; border-radius: 4px; font-size: 12px; font-weight: 500;">
+                                ID: ${outItem.id} - ${outItem.name}
+                            </span>
+                        </c:forEach>
+                    </div>
+                </div>
+            </c:if>
+
+            <div style="display: flex; gap: 10px; margin-bottom: 15px;">
+                <button type="button" class="stock-tab-btn active" data-filter="all" style="padding: 8px 16px; border: none; border-radius: 4px; font-weight: 600; cursor: pointer; background: #8b572a; color: white;">Tất cả</button>
+                <button type="button" class="stock-tab-btn" data-filter="empty" style="padding: 8px 16px; border: none; border-radius: 4px; font-weight: 600; cursor: pointer; background: #e2e8f0; color: #4a5568;"><i class="fa-solid fa-circle-xmark" style="color: #e53e3e;"></i> Đã hết hàng</button>
+                <button type="button" class="stock-tab-btn" data-filter="warning" style="padding: 8px 16px; border: none; border-radius: 4px; font-weight: 600; cursor: pointer; background: #e2e8f0; color: #4a5568;"><i class="fa-solid fa-circle-exclamation" style="color: #dd6b20;"></i> Sắp hết (&lt; 10)</button>
+            </div>
+
             <c:if test="${not empty param.message}">
                 <div style="padding: 10px; margin-bottom: 15px; background: #d4edda; color: #155724; border-radius: 5px;">
                     <c:choose>
@@ -62,20 +82,21 @@
                     </tr>
                     </thead>
                     <tbody>
-
-                    
                     <c:forEach items="${listProducts}" var="p">
-                        <tr class="product-row">
+                        <tr class="product-row" data-stock="${p.stock}">
                             <td class="col-checkbox">
                                 <input type="checkbox" name="product_ids[]" value="${p.id}">
                             </td>
                             <td class="col-image">
                                 <div class="product-thumbnail">
-                                        
-                                    <img src="${p.imageUrl}" alt="${p.name}"
-                                         >
-
-                                        
+                                    <c:choose>
+                                        <c:when test="${fn:startsWith(p.imageUrl, 'http')}">
+                                            <img src="${p.imageUrl}" alt="${p.name}">
+                                        </c:when>
+                                        <c:otherwise>
+                                            <img src="${pageContext.request.contextPath}/${p.imageUrl}" alt="${p.name}">
+                                        </c:otherwise>
+                                    </c:choose>
                                     <c:if test="${p.featured}">
                                         <span class="featured-badge"><i class="fa-solid fa-star"></i></span>
                                     </c:if>
@@ -98,7 +119,7 @@
                                             <span class="price-old" style="text-decoration: line-through; color: #999; font-size: 0.8em;">
                                                 <fmt:formatNumber value="${p.price}" type="currency" currencySymbol="đ"/>
                                             </span><br>
-                                                                        <span class="price-sale" style="color: #e74c3c; font-weight: bold;">
+                                            <span class="price-sale" style="color: #e74c3c; font-weight: bold;">
                                                 <fmt:formatNumber value="${p.getSalePrice()}" type="currency" currencySymbol="đ"/>
                                             </span>
                                         </c:when>
@@ -110,8 +131,6 @@
                                     </c:choose>
                                 </div>
                             </td>
-
-                                
                             <td class="col-sale">
                                 <c:choose>
                                     <c:when test="${p.discountPercent > 0}">
@@ -126,14 +145,19 @@
                             </td>
                             <td class="col-stock">
                                 <div class="stock-wrapper">
-                                        
-                                    <span class="stock-number ${p.stock < 10 ? 'stock-critical' : 'stock-normal'}">
-                                            ${p.stock}
-                                    </span>
+                                    <c:choose>
+                                        <c:when test="${p.stock == 0}">
+                                            <span style="background: #fed7d7; color: #9b2c2c; padding: 2px 6px; border-radius: 4px; font-weight: bold; font-size: 13px;">Hết hàng</span>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <span class="stock-number ${p.stock < 10 ? 'stock-critical' : 'stock-normal'}">
+                                                    ${p.stock}
+                                            </span>
+                                        </c:otherwise>
+                                    </c:choose>
                                 </div>
                             </td>
                             <td class="col-status">
-                                    
                                 <c:choose>
                                     <c:when test="${p.status == 'active'}">
                                         <span class="status-badge status-active">Đang bán</span>
@@ -145,55 +169,51 @@
                             </td>
                             <td class="col-actions">
                                 <div class="action-buttons">
-                                    <a href="${pageContext.request.contextPath}/admin/products?action=edit&id=${p.id}"
-                                       class="btn-action btn-edit" title="Chỉnh sửa">
-                                        <i class="fa-solid fa-pen"></i>
-                                    </a>
-                                    <a href="${pageContext.request.contextPath}/admin/products?action=delete&id=${p.id}"
-                                       class="btn-action btn-delete"
-                                       title="Xóa"
-                                       onclick="return confirm('Bạn có chắc chắn muốn xóa sản phẩm ID: ${p.id} không?');">
-                                        <i class="fa-solid fa-trash"></i>
-                                    </a>
+                                    <a href="${pageContext.request.contextPath}/admin/products?action=edit&id=${p.id}" class="btn-action btn-edit" title="Chỉnh sửa"><i class="fa-solid fa-pen"></i></a>
+                                    <a href="${pageContext.request.contextPath}/admin/products?action=delete&id=${p.id}" class="btn-action btn-delete" title="Xóa" onclick="return confirm('Bạn có chắc chắn muốn xóa sản phẩm ID: ${p.id} không?');"><i class="fa-solid fa-trash"></i></a>
                                 </div>
                             </td>
                         </tr>
                     </c:forEach>
-                    
-
                     </tbody>
                 </table>
             </div>
-
         </div>
     </div>
 </main>
 <script>
     $(document).ready(function() {
-        
         const vietnameseLanguage = {
-            "sProcessing":   "Đang xử lý...",
-            "sLengthMenu":   "Xem _MENU_ mục",
-            "sZeroRecords":  "Không tìm thấy dòng nào phù hợp",
-            "sInfo":         "Đang xem _START_ đến _END_ trong tổng số _TOTAL_ mục",
-            "sInfoEmpty":    "Đang xem 0 đến 0 trong tổng số 0 mục",
-            "sInfoFiltered": "(được lọc từ _MAX_ mục)",
-            "sSearch":       "Tìm kiếm:",
-            "oPaginate": {
-                "sFirst":    "Đầu",
-                "sPrevious": "Trước",
-                "sNext":     "Tiếp",
-                "sLast":     "Cuối"
-            }
+            "sProcessing": "Đang xử lý...", "sLengthMenu": "Xem _MENU_ mục", "sZeroRecords": "Không tìm thấy dòng nào phù hợp",
+            "sInfo": "Đang xem _START_ đến _END_ trong tổng số _TOTAL_ mục", "sInfoEmpty": "Đang xem 0 đến 0 trong tổng số 0 mục",
+            "sSearch": "Tìm kiếm:",
+            "oPaginate": { "sFirst": "Đầu", "sPrevious": "Trước", "sNext": "Tiếp", "sLast": "Cuối" }
         };
 
-        $('#productTable').DataTable({
-            "language": vietnameseLanguage, 
-            "columnDefs": [
-                { "orderable": false, "targets": [0, 1, 7] }
-            ],
-            "pageLength": 10,
-            "order": [[2, 'asc']]
+        const table = $('#productTable').DataTable({
+            "language": vietnameseLanguage,
+            "columnDefs": [{ "orderable": false, "targets": [0, 1, 7] }],
+            "pageLength": 10, "order": [[2, 'asc']]
+        });
+
+        $('.stock-tab-btn').on('click', function() {
+            $('.stock-tab-btn').css({'background': '#e2e8f0', 'color': '#4a5568'}).removeClass('active');
+            $(this).css({'background': '#8b572a', 'color': 'white'}).addClass('active');
+
+            const filterType = $(this).data('filter');
+            $.fn.dataTable.ext.search.pop();
+
+            if (filterType === 'empty') {
+                $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
+                    return parseInt($(table.row(dataIndex).node()).data('stock')) === 0;
+                });
+            } else if (filterType === 'warning') {
+                $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
+                    const s = parseInt($(table.row(dataIndex).node()).data('stock'));
+                    return s > 0 && s < 10;
+                });
+            }
+            table.draw();
         });
     });
 </script>

--- a/src/main/webapp/shopping-cart.jsp
+++ b/src/main/webapp/shopping-cart.jsp
@@ -52,7 +52,7 @@
                                 <input type = "checkbox" value = "${item.product.id}" class = "item-checkbox single-check" data-price = "${item.price}" data-qty = "${item.quantity}">
                                 <div class="cart-items">
                                     <a href="productdetail?id=${item.product.id}" class="cart-item">
-                                        <img src="${pageContext.request.contextPath}/${item.product.imageUrl}" alt="image" width="80">
+                                        <img src="${item.product.imageUrl}" alt="image" width="80">
                                     </a>
                                     <div class="cart-info">
                                         <strong class="cart-item-name">${item.product.name}</strong>


### PR DESCRIPTION
**VẤN ĐỀ ĐÃ PHÁT HIỆN & GIẢI QUYẾT:**

- Lỗi logic taglib Core: Đặt thuộc tính var="hasOut" sai ngữ cảnh trong thẻ <c:if> tại trang danh sách sản phẩm khiến banner cảnh báo hết hàng không render.
- Lệch pha luồng giỏ hàng: Giỏ hàng Session vãng lai bị xóa sạch/không bàn giao sang Session đăng nhập mới sau khi login thành công khiến trang checkout bị redirect ngược về shopping-cart.jsp.
- Trống màn hình kho: Gọi nhầm tên cột p.totalSold (biến Java Model) trong câu truy vấn SQL thay vì cột p.sold_quantity vật lý dưới database khiến trang quản lý kho bị lỗi SQLException và không bốc được danh sách sản phẩm.
- Thiếu phân trang kho: Trang kho tải một lúc hơn 200 sản phẩm lên giao diện gây đơ trình duyệt và mất hoàn toàn dữ liệu ô dữ liệu Input gõ nhập thêm khi Admin bấm chuyển trang.
- Lỗi logic trừ kho online: Khi mua hàng bằng Ví điện tử (VNPAY/MoMo), hệ thống chưa có chốt chặn kiểm soát trừ kho vật lý dẫn đến sai lệch số lượng.

**NỘI DUNG ĐÃ THỰC HIỆN:**
   - Tạo tầng dữ liệu InventoryDao xử lý truy vấn động lấy danh sách sản phẩm, ánh xạ cột `sold_quantity` dưới DB sang thuộc tính `totalSold` của Java Model.
   - Viết hàm importStockBatch sử dụng JDBC Batch Update kết hợp Database Transaction (setAutoCommit(false)) để cộng dồn số lượng tồn kho hàng loạt an toàn.
   - Tạo AdminInventoryServlet tiếp nhận mảng productIds và stockAdds truyền tải từ biểu mẫu giao diện.
   - Tách biệt hoàn toàn mã nhúng CSS thô sang file CSS độc lập, chuyển dịch hệ màu sang tông Xám-Trắng-Đen phẳng phiu đồng bộ với layout hệ thống.
   - Loại bỏ toàn bộ các thẻ Icon trực quan rườm rà theo yêu cầu tối giản.
   - Tích hợp thư viện jQuery DataTables phân trang 10 sản phẩm/trang, bổ sung đoạn mã Script ép giữ trạng thái và gom toàn bộ ô dữ liệu Input ẩn liên trang khi nhấn nút Submit gửi đi.
   - Nâng cấp CheckoutServlet: Lấy giỏ hàng bền vững qua CartDAO dựa theo user.id thay vì Session thuần; Chèn Transaction tự động trừ kho, tăng sold_quantity và ghi nhật ký EXPORT ngay khi người dùng chọn phương thức Tiền mặt COD thành công.
   - Tích hợp hàm dọn dẹp CartDAO xóa sạch các item đã mua thành công ra khỏi bảng giỏ hàng dưới Database.
   - Tích hợp luồng xử lý ngầm tại AdminOrderServlet: Khi Admin duyệt chuyển trạng thái đơn sang 'Hoàn thành' hoặc 'completed', hệ thống tự động trừ kho vật lý đồng bộ thời gian thực.
   - Chạy lệnh SQL phân bổ 210 sản phẩm mây tre đan nhập kho rải rác theo mốc thời gian động 5 tháng (từ tháng 2 đến tháng 6/2026) giúp biểu đồ Dashboard nhảy số tăng trưởng chính xác.
   - Closes #76 
   - Closes #80 
   - Closes #81
   - Closes #82 
   - Closes #83 
 