### PR TITLE
feat: Thêm tìm kiếm cho trang quản lí đơn hàng

### DIFF
--- a/src/main/java/com/example/backend/controller/admin/AdminOrderServlet.java
+++ b/src/main/java/com/example/backend/controller/admin/AdminOrderServlet.java
@@ -3,6 +3,7 @@ package com.example.backend.controller.admin;
 import com.example.backend.dao.OrderDao;
 import com.example.backend.model.Order;
 import com.example.backend.model.OrderItem;
+import com.example.backend.model.User;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import jakarta.servlet.annotation.*;
@@ -19,6 +20,12 @@ public class AdminOrderServlet extends HttpServlet {
         request.setCharacterEncoding("UTF-8");
         response.setCharacterEncoding("UTF-8");
 
+        HttpSession session = request.getSession();
+        User user = (User) session.getAttribute("user");
+        if(user == null || user.getRoleId()!=1){
+            response.sendRedirect(request.getContextPath()+"/login");
+            return;
+        }
         String action = request.getParameter("action");
         if (action == null) {
             action = "list";
@@ -40,7 +47,14 @@ public class AdminOrderServlet extends HttpServlet {
         int page = 1;
         int pageSize = 1000;
 
-        List<Order> orders = orderDao.getAllOrders();
+        List<Order> orders;
+        String search = request.getParameter("search");
+        if(search!=null && !search.trim().isEmpty()){
+            orders = orderDao.searchOrdersByName(search);
+            request.setAttribute("searchQuery",search.trim());
+        }else{
+            orders = orderDao.getAllOrders();
+        }
         int totalOrders = orders.size();
 
         request.setAttribute("orders", orders);
@@ -75,6 +89,12 @@ public class AdminOrderServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         request.setCharacterEncoding("UTF-8");
+        HttpSession session = request.getSession();
+        User user = (User) session.getAttribute("user");
+        if (user == null || user.getRoleId() != 1) {
+            response.sendRedirect(request.getContextPath() + "/login");
+            return;
+        }
         String action = request.getParameter("action");
 
         if ("updateStatus".equals(action)) {

--- a/src/main/java/com/example/backend/dao/OrderDao.java
+++ b/src/main/java/com/example/backend/dao/OrderDao.java
@@ -314,5 +314,39 @@ public class OrderDao {
         }
         return list;
     }
+    public List<Order> searchOrdersByName(String keyword){
+        List<Order> list = new ArrayList<>();
+        String sql = "SELECT DISTINCT o.* FROM orders o " +
+                "LEFT JOIN order_items oi ON o.id = oi.order_id " +
+                "LEFT JOIN products p ON oi.product_id = p.id " +
+                "WHERE o.shipping_name LIKE ? OR p.name LIKE ? " +
+                "ORDER BY o.id DESC";
+        try(Connection con = DBConnection.getConnection();
+        PreparedStatement pre = con.prepareStatement(sql)){
+            String searchPattern = "%" + keyword.trim() + "%";
+            pre.setString(1,searchPattern);
+            pre.setString(2,searchPattern);
+            ResultSet rs = pre.executeQuery();
+            while (rs.next()) {
+                Order o = new Order();
+                o.setId(rs.getInt("id"));
+                o.setUser_id(rs.getInt("user_id"));
+                o.setShipping_name(rs.getString("shipping_name"));
+                o.setShipping_phone(rs.getString("shipping_phone"));
+                o.setShipping_address(rs.getString("shipping_address"));
+                o.setNote(rs.getString("note"));
+                o.setShipping_fee(rs.getDouble("shipping_fee"));
+                o.setTotal_amount(rs.getDouble("total_amount"));
+                o.setOrder_status(rs.getString("order_status"));
+                o.setEstimated_delivery_date(rs.getDate("estimated_delivery_date"));
+                o.setCreated_at(rs.getTimestamp("created_at"));
+                o.setUpdated_at(rs.getTimestamp("updated_at"));
+                list.add(o);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
 
 }

--- a/src/main/webapp/admin/css/orders-list.css
+++ b/src/main/webapp/admin/css/orders-list.css
@@ -745,3 +745,105 @@
     outline: 2px solid var(--admin-accent);
     outline-offset: 2px;
 }
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    flex-wrap: wrap; /* Tránh vỡ layout trên màn hình nhỏ */
+    gap: 15px;
+}
+
+.search-form {
+    display: flex;
+    position: relative;
+    width: 300px;
+    max-width: 100%;
+}
+
+.search-icon {
+    position: absolute;
+    left: 15px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--admin-text-soft, #888);
+    font-size: 14px;
+    pointer-events: none; /* Tránh click nhầm vào icon thay vì input */
+}
+
+.search-input {
+    width: 100%;
+    padding: 10px 15px 10px 40px;
+    border: 1px solid var(--admin-border-subtle, #ddd);
+    border-radius: var(--admin-radius-sm, 8px);
+    font-size: 14px;
+    color: var(--admin-text-main, #333);
+    background-color: var(--admin-surface, #fff);
+    box-shadow: 0 2px 5px rgba(0,0,0,0.02);
+    transition: all 0.3s ease;
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--admin-accent, #e67e22);
+    box-shadow: 0 0 0 3px var(--admin-accent-soft, rgba(230, 126, 34, 0.15));
+}
+
+.search-input::placeholder {
+    color: var(--admin-text-muted, #999);
+}
+
+/* --- 2. Empty State (Khi không có đơn hàng) --- */
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 80px 20px;
+    background: var(--admin-surface, #fff);
+    border-radius: var(--admin-radius-md, 8px);
+    border: 2px dashed var(--admin-border-subtle, #eee);
+    margin-top: 20px;
+}
+
+.empty-icon {
+    font-size: 64px;
+    color: var(--admin-border-strong, #ccc);
+    margin-bottom: 24px;
+}
+
+.empty-state h3 {
+    color: var(--admin-text-main, #333);
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.empty-state p {
+    color: var(--admin-text-muted, #777);
+    font-size: 14px;
+    margin-bottom: 24px;
+    max-width: 400px;
+}
+
+.btn-clear-search {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 24px;
+    background-color: var(--admin-surface-alt, #f9f9f9);
+    color: var(--admin-text-main, #333);
+    text-decoration: none;
+    border-radius: var(--admin-radius-sm, 6px);
+    font-weight: 500;
+    font-size: 14px;
+    border: 1px solid var(--admin-border-subtle, #ddd);
+    transition: all 0.2s ease;
+}
+
+.btn-clear-search:hover {
+    background-color: var(--admin-border-subtle, #eee);
+    color: var(--admin-accent, #e67e22);
+    border-color: var(--admin-border-strong, #ccc);
+}

--- a/src/main/webapp/admin/orders/order-list.jsp
+++ b/src/main/webapp/admin/orders/order-list.jsp
@@ -33,9 +33,17 @@
                 <a href="#" class="tab-item active" data-status="all"><span class="tab-label">Tất cả</span></a>
                 <a href="#" class="tab-item pending" data-status="pending"><span class="tab-label">Chờ xác nhận</span></a>
                 <a href="#" class="tab-item completed" data-status="completed"><span class="tab-label">Hoàn thành</span></a>
+                <div class="header-right">
+                    <form action="orders" method="GET" class="search-form">
+                        <i class="fa-solid fa-magnifying-glass search-icon"></i>
+                        <input type="text" name="search" value="${searchQuery}" placeholder="Tìm kiếm" class="search-input">
+                    </form>
+                </div>
             </div>
 
             <div class="orders-table-container" style="margin-top: 20px;">
+                <c:choose>
+                <c:when test="${not empty orders}">
                 <table class="orders-table" id="adminOrderTable">
                     <thead>
                     <tr>
@@ -97,6 +105,18 @@
                     </c:forEach>
                     </tbody>
                 </table>
+                </c:when>
+                    <c:otherwise>
+                        <div class="empty-state">
+                            <i class="fa-solid fa-file-invoice empty-icon"></i>
+                            <h3>Không tìm thấy đơn hàng nào!</h3>
+                            <p>Rất tiếc, không có đơn hàng nào khớp với tìm kiếm của bạn.</p>
+                            <a href="orders" class="btn-clear-search">
+                                <i class="fa-solid fa-rotate-left"></i> Xóa tìm kiếm và Tải lại
+                            </a>
+                        </div>
+                    </c:otherwise>
+                </c:choose>
             </div>
         </div>
     </div>
@@ -122,7 +142,9 @@
                 }
             });
 
+            if($('.order-row').length>0){
             $('#order-count-label').text(visibleCount + " đơn hàng");
+            }
         });
     });
 </script>


### PR DESCRIPTION
Thêm phương thức searchOrders(String keyword) sử dụng truy vấn JOIN bảng orders, order_items và products để tra cứu chuỗi LIKE tương đối. Đã áp dụng DISTINCT để tránh trùng lặp kết quả.
Cập nhật phương thức viewOrderList để bắt tham số search từ URL và điều hướng dữ liệu trả về JSP.
Thêm thanh tìm kiếm tinh gọn trên Header.
Bổ sung giao diện khi không tìm thấy kết quả khớp với từ khóa.
Closes #85